### PR TITLE
Add Codecov badge and improve test coverage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # copick-torch
 
+[![codecov](https://codecov.io/gh/copick/copick-torch/branch/main/graph/badge.svg)](https://codecov.io/gh/copick/copick-torch)
+
 Torch utilities for [copick](https://github.com/copick/copick)
 
 ## Quick demo
@@ -23,8 +25,15 @@ pytest
 ### View coverage report
 
 ```bash
-pytest --cov=copick_torch
+# Generate terminal, HTML and XML coverage reports
+pytest --cov=copick_torch --cov-report=term --cov-report=html --cov-report=xml
 ```
+
+After running the tests with coverage, you can:
+
+1. View the terminal report directly in your console
+2. Open `htmlcov/index.html` in a browser to see the detailed HTML report
+3. Check the [Codecov dashboard](https://codecov.io/gh/copick/copick-torch) for the project's coverage metrics
 
 ## Code of Conduct
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -47,6 +47,7 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
+  show_carryforward_flags: true
 
 ignore:
   - "examples/**/*"


### PR DESCRIPTION
This PR enhances test coverage visibility for the repository:

1. Adds a Codecov badge to the README for quick visibility of coverage status
2. Improves documentation on how to view coverage reports both locally and on Codecov
3. Enhances Codecov configuration for better PR comments and visualization

After merging this PR, coverage metrics will be visible:
- Directly in GitHub with the Codecov badge showing current coverage percentage
- On the [Codecov dashboard](https://codecov.io/gh/copick/copick-torch) with detailed metrics
- In PRs as Codecov comments showing coverage changes

This PR complements the workflow file change that was already made directly on main to generate XML coverage reports for Codecov.