### PR TITLE
Add self-contained code coverage reporting

### DIFF
--- a/.github/ci_post_test_example.yml
+++ b/.github/ci_post_test_example.yml
@@ -1,0 +1,16 @@
+# Example of how to add the coverage reporting to your workflow
+# Copy and paste these steps into your existing workflow
+
+# After your existing test step that runs pytest with coverage:
+- name: Generate Coverage Reports
+  run: |
+    bash scripts/ci_post_test.sh
+
+- name: Upload Coverage Reports
+  uses: actions/upload-artifact@v3
+  with:
+    name: coverage-reports-${{ matrix.python-version }}
+    path: |
+      htmlcov/
+      coverage.xml
+      coverage-badge.svg

--- a/CI_COVERAGE_SETUP.md
+++ b/CI_COVERAGE_SETUP.md
@@ -1,0 +1,55 @@
+# GitHub Actions Coverage Reporting
+
+This document explains how to use the included coverage reporting tools with GitHub Actions.
+
+## Overview
+
+The repository includes scripts to generate code coverage reports and badges that work both locally and in CI environments. These tools provide a way to visualize code coverage without relying on external services like Codecov.
+
+## How to Add to GitHub Actions Workflow
+
+To add coverage reporting to the existing GitHub Actions workflow, simply add the following step after the test step. This doesn't require changing the existing workflow structure.
+
+```yaml
+- name: Generate Coverage Reports
+  run: |
+    bash scripts/ci_post_test.sh
+
+- name: Upload Coverage Reports
+  uses: actions/upload-artifact@v3
+  with:
+    name: coverage-reports-${{ matrix.python-version }}
+    path: |
+      htmlcov/
+      coverage.xml
+      coverage-badge.svg
+```
+
+## What This Provides
+
+1. **GitHub Actions Summary** - A coverage summary will be added directly to the GitHub Actions run summary page
+2. **Coverage Badge** - A self-contained SVG badge displaying the coverage percentage
+3. **Report Artifacts** - HTML and XML reports available as downloadable artifacts
+
+## Local Usage
+
+You can also use these tools locally:
+
+```bash
+# Run tests and generate all reports with a badge
+python -m scripts.coverage_report --term
+
+# View HTML report
+open htmlcov/index.html
+
+# Use the badge in your documentation
+# The file will be at: coverage-badge.svg
+```
+
+## Advantages
+
+- No external service dependencies
+- Self-contained reporting
+- Works identically in CI and locally
+- Provides visibility directly in GitHub Actions UI
+- Doesn't require changes to existing workflow structure

--- a/README.md
+++ b/README.md
@@ -29,11 +29,19 @@ pytest
 pytest --cov=copick_torch --cov-report=term --cov-report=html --cov-report=xml
 ```
 
+Or use the self-contained coverage script:
+
+```bash
+# Run tests and generate coverage reports with badge
+python scripts/coverage_report.py --term
+```
+
 After running the tests with coverage, you can:
 
 1. View the terminal report directly in your console
 2. Open `htmlcov/index.html` in a browser to see the detailed HTML report
-3. Check the [Codecov dashboard](https://codecov.io/gh/copick/copick-torch) for the project's coverage metrics
+3. View the generated coverage badge (`coverage-badge.svg`)
+4. Check the [Codecov dashboard](https://codecov.io/gh/copick/copick-torch) for the project's coverage metrics
 
 ## Code of Conduct
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ test = [
     "pytest-cov"
 ]
 
+[project.scripts]
+coverage-report = "scripts.coverage_report:main"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+"""
+copick-torch utility scripts
+"""

--- a/scripts/ci_coverage_summary.py
+++ b/scripts/ci_coverage_summary.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Script to generate GitHub Actions coverage summary from an existing coverage.xml file.
+This script is designed to be added to the CI workflow without modifying the workflow file.
+
+Usage:
+  python -m scripts.ci_coverage_summary
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def main():
+    """Generate GitHub Actions coverage summary."""
+    # Check if we're running in GitHub Actions
+    if 'GITHUB_STEP_SUMMARY' not in os.environ:
+        print("Not running in GitHub Actions, skipping summary generation.")
+        return 0
+    
+    try:
+        # Check if coverage.xml exists
+        if not Path('coverage.xml').exists():
+            print("coverage.xml not found, skipping summary generation.")
+            return 1
+        
+        # Parse coverage data
+        tree = ET.parse('coverage.xml')
+        root = tree.getroot()
+        line_rate = float(root.attrib["line-rate"]) * 100
+        
+        # Write summary
+        summary_file = os.environ['GITHUB_STEP_SUMMARY']
+        with open(summary_file, 'a') as f:
+            f.write(f"## Coverage Summary\n\n")
+            f.write(f"Total coverage: {line_rate:.2f}%\n\n")
+            
+            # Get package details
+            packages = root.findall(".//package")
+            if packages:
+                f.write("| Package | Line Coverage | Branch Coverage |\n")
+                f.write("|---------|--------------|----------------|\n")
+                
+                for package in packages:
+                    pkg_name = package.attrib.get('name', 'Unknown')
+                    pkg_line_rate = float(package.attrib.get('line-rate', 0)) * 100
+                    pkg_branch_rate = float(package.attrib.get('branch-rate', 0)) * 100
+                    f.write(f"| {pkg_name} | {pkg_line_rate:.2f}% | {pkg_branch_rate:.2f}% |\n")
+            
+            f.write("\nSee artifacts for detailed coverage report.\n")
+        
+        print(f"Added coverage summary to GitHub Actions report")
+        return 0
+    
+    except Exception as e:
+        print(f"Error generating summary: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_post_test.sh
+++ b/scripts/ci_post_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Post-test steps for CI
+# This script can be added as a separate step in the CI workflow
+# without modifying the workflow file structure
+#
+
+set -e
+
+# Generate GitHub Actions summary
+echo "Generating GitHub Actions summary..."
+python -m scripts.ci_coverage_summary
+
+# Generate coverage badge
+echo "Generating coverage badge..."
+python -m scripts.coverage_report --skip-tests
+
+# If we're in GitHub Actions, display info about where to find reports
+if [ -n "$GITHUB_ACTIONS" ]; then
+  echo "Coverage reports generated:"
+  echo "- coverage.xml (XML report)"
+  echo "- htmlcov/ (HTML report)"
+  echo "- coverage-badge.svg (Coverage badge)"
+  echo "These can be uploaded as GitHub Actions artifacts."
+fi
+
+exit 0

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Generate code coverage reports with a self-contained badge.
+This script can be used both locally and in CI environments.
+"""
+
+import os
+import subprocess
+import xml.etree.ElementTree as ET
+import argparse
+import sys
+from pathlib import Path
+
+
+def run_tests_with_coverage(args):
+    """Run tests with coverage reporting."""
+    cmd = [
+        "pytest",
+        f"--cov={args.package}",
+        "--cov-report=xml",
+        "--cov-report=html",
+    ]
+    if args.term:
+        cmd.append("--cov-report=term")
+    
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def generate_badge(coverage_rate, output_path):
+    """Generate a simple SVG coverage badge."""
+    # Determine color based on coverage rate
+    if coverage_rate >= 90:
+        color = "brightgreen"
+    elif coverage_rate >= 80:
+        color = "green"
+    elif coverage_rate >= 70:
+        color = "yellowgreen"
+    elif coverage_rate >= 60:
+        color = "yellow"
+    elif coverage_rate >= 50:
+        color = "orange"
+    else:
+        color = "red"
+    
+    # SVG template
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" width="104" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="104" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h61v20H0z"/>
+        <path fill="#{color}" d="M61 0h43v20H61z"/>
+        <path fill="url(#b)" d="M0 0h104v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="30.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="30.5" y="14">coverage</text>
+        <text x="82.5" y="15" fill="#010101" fill-opacity=".3">{coverage_rate:.1f}%</text>
+        <text x="82.5" y="14">{coverage_rate:.1f}%</text>
+    </g>
+</svg>'''
+    
+    with open(output_path, 'w') as f:
+        f.write(svg)
+    
+    print(f"Coverage badge saved to {output_path}")
+
+
+def extract_coverage_from_xml():
+    """Extract coverage data from coverage.xml file."""
+    try:
+        tree = ET.parse('coverage.xml')
+        root = tree.getroot()
+        line_rate = float(root.attrib["line-rate"]) * 100
+        return line_rate
+    except (FileNotFoundError, KeyError) as e:
+        print(f"Error extracting coverage data: {e}")
+        return 0.0
+
+
+def print_github_actions_summary(coverage_rate, badge_path):
+    """Print summary for GitHub Actions."""
+    if 'GITHUB_STEP_SUMMARY' in os.environ:
+        summary_file = os.environ['GITHUB_STEP_SUMMARY']
+        with open(summary_file, 'a') as f:
+            f.write(f"## Coverage Summary\n\n")
+            f.write(f"![Coverage]({badge_path})\n\n")
+            f.write(f"Total coverage: {coverage_rate:.2f}%\n\n")
+            f.write("See artifacts for detailed coverage report.\n")
+        print(f"Added coverage summary to GitHub Actions report")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate code coverage reports and badge")
+    parser.add_argument("--package", default="copick_torch", 
+                        help="Package to measure coverage for (default: copick_torch)")
+    parser.add_argument("--output", default="coverage-badge.svg",
+                        help="Output path for the coverage badge (default: coverage-badge.svg)")
+    parser.add_argument("--term", action="store_true", 
+                        help="Also generate terminal coverage report")
+    parser.add_argument("--skip-tests", action="store_true",
+                        help="Skip running tests (use existing coverage data)")
+    
+    args = parser.parse_args()
+    
+    # Make sure the output directory exists
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    if not args.skip_tests:
+        # Run tests with coverage
+        ret_code = run_tests_with_coverage(args)
+        if ret_code != 0:
+            print("Tests failed!")
+            sys.exit(ret_code)
+    
+    # Extract coverage data from xml
+    coverage_rate = extract_coverage_from_xml()
+    
+    # Generate badge
+    generate_badge(coverage_rate, args.output)
+    
+    # If running in GitHub Actions, add to summary
+    print_github_actions_summary(coverage_rate, args.output)
+    
+    print(f"Total coverage: {coverage_rate:.2f}%")
+    print(f"HTML report available at: htmlcov/index.html")
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Overview

This PR adds a self-contained code coverage reporting solution that doesn't require additional GitHub configuration. It addresses the issue where Codecov doesn't seem to be updating properly.

## Changes

- Added a Python script (`scripts/coverage_report.py`) to generate coverage reports and badges
- Added a CI helper script (`scripts/ci_post_test.sh`) to integrate with GitHub Actions
- Added a summary generator (`scripts/ci_coverage_summary.py`) to create GitHub Actions step summaries
- Added documentation for how to use these tools
- Updated README with new coverage reporting instructions
- Updated pyproject.toml to include the script as an executable

## Benefits

- Works without any external service dependencies
- Coverage badge is generated and visible directly in GitHub Actions
- Coverage summary appears in GitHub Actions step summary
- Reports are saved as artifacts for easy access
- Can be used locally as well as in CI
- Does not require changes to existing workflow files (simply add the new steps)

## How to Use

Locally:
```bash
python -m scripts.coverage_report --term
```

In CI:
1. Add the steps from `.github/ci_post_test_example.yml` to your workflow
2. No other configuration needed

## Screenshots

<Insert screenshot of coverage summary and badge here after first CI run>

## Notes

This PR maintains the existing Codecov integration as a fallback, so both systems can work in parallel until the team is confident in the new approach.

See `CI_COVERAGE_SETUP.md` for detailed instructions.
