### PR TITLE
Fix test_getitem_no_augment to handle dictionary labels

### DIFF
--- a/tests/test_copick_dataset.py
+++ b/tests/test_copick_dataset.py
@@ -119,7 +119,8 @@ class TestCopickDataset(unittest.TestCase):
         # Check shapes and types
         self.assertEqual(volume.shape, (1, *self.boxsize))  # Check channel dimension added
         self.assertIsInstance(volume, torch.Tensor)
-        self.assertEqual(label.item(), 0)
+        self.assertIsInstance(label, dict)  # Verify label is a dictionary
+        self.assertEqual(label['class_idx'], 0)  # Check if class_idx is correct
     
     @patch('copick_torch.copick.CopickDataset._load_data')
     def test_stratified_split(self, mock_load_data):


### PR DESCRIPTION
## Description
This PR fixes the failing CI test by updating the `test_getitem_no_augment` test to handle the new dictionary format for labels that was introduced in the `CopickDataset.__getitem__` method.

## Changes
- Updated the test assertions to check that label is a dictionary and validate the 'class_idx' key instead of using .item()

## Fix Details
The test was expecting the label to be a tensor with an `.item()` method, but the implementation has changed to return a dictionary with labels and metadata. This PR updates the test to match the current implementation.

## Tested
The updated test should now pass with the current implementation.