### PR TITLE
Fix missing patch import in tests

### DIFF
--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -2,6 +2,7 @@
 import unittest
 import torch
 import numpy as np
+from unittest.mock import patch
 from copick_torch import MixupAugmentation
 
 


### PR DESCRIPTION
This PR fixes the test import issues that are causing the CI pipeline to fail.

The main issue was in `tests/test_augmentations.py` where the `patch` decorator was used but not imported. I've added:

```python
from unittest.mock import patch
```

to fix this issue.

This should resolve the following error in CI:
```
ERROR tests/test_augmentations.py - NameError: name 'patch' is not defined
```

This is a simple fix that should help restore the test coverage improvements we've been working on.