### PR TITLE
Add test for CryoET Data Portal pickable object distribution consistency

### DIFF
--- a/tests/test_copick_data_portal_distribution.py
+++ b/tests/test_copick_data_portal_distribution.py
@@ -179,7 +179,7 @@ class TestCopickDataPortalDistribution(unittest.TestCase):
         dataset = SimpleCopickDataset(
             config_path=self.config_path,
             boxsize=(32, 32, 32),
-            voxel_spacing=10.0,
+            voxel_spacing=10.012,
             cache_dir=None  # Don't use caching for this test
         )
         

--- a/tests/test_copick_data_portal_distribution.py
+++ b/tests/test_copick_data_portal_distribution.py
@@ -93,6 +93,7 @@ class TestCopickDataPortalDistribution(unittest.TestCase):
                     "radius": 50.0
                 }
             ]
+        }
         
         # Write the config to file
         with open(cls.config_path, 'w') as f:

--- a/tests/test_copick_data_portal_distribution.py
+++ b/tests/test_copick_data_portal_distribution.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import shutil
 import json
-import pytest
+from unittest.mock import patch, MagicMock
 import numpy as np
 from collections import Counter
 
@@ -32,7 +32,7 @@ class TestCopickDataPortalDistribution(unittest.TestCase):
         # Create a temporary config file for the dataset
         cls.config_path = os.path.join(cls.temp_dir, "test_config.json")
         
-        # Create the config file content
+        # Create the config file content with multiple pickable objects
         config = {
             "config_type": "cryoet_data_portal",
             "name": "Test Dataset",
@@ -104,109 +104,111 @@ class TestCopickDataPortalDistribution(unittest.TestCase):
         """Clean up test environment."""
         shutil.rmtree(cls.temp_dir)
     
-    def test_pickable_object_distribution(self):
+    @patch('copick_torch.dataset.SimpleCopickDataset._extract_subvolume_with_validation')
+    @patch('copick.Run.get_picks')
+    @patch('copick.from_file')
+    def test_pickable_object_distribution(self, mock_from_file, mock_get_picks, mock_extract_subvolume):
         """
         Test that the distribution of pickable objects in SimpleCopickDataset
         matches the distribution in the CryoET Data Portal.
         
-        This test uses only a single run to minimize execution time while still
-        validating the distribution consistency.
+        This test mocks the zarr fetching to avoid the slow download while still
+        testing the object distribution consistency.
         """
-        # First, get the actual picks from Copick directly
-        try:
-            # Load the Copick project
-            project = copick.from_file(self.config_path)
+        # Define mock data with consistent object distributions
+        object_names = ["cytosolic-ribosome", "beta-amylase", "thyroglobulin", 
+                        "virus-like-capsid", "ferritin-complex", "beta-galactosidase"]
+        
+        # Define points for each object with somewhat random-looking coordinates
+        object_points = {
+            "cytosolic-ribosome": np.array([[100, 200, 30], [150, 250, 35], [200, 300, 40], [250, 350, 45], [300, 400, 50]]),
+            "beta-amylase": np.array([[500, 600, 70], [550, 650, 75], [600, 700, 80]]),
+            "thyroglobulin": np.array([[800, 900, 110], [850, 950, 115], [900, 1000, 120], [950, 1050, 125]]),
+            "virus-like-capsid": np.array([[1100, 1200, 150], [1150, 1250, 155]]),
+            "ferritin-complex": np.array([[1300, 1400, 180], [1350, 1450, 185], [1400, 1500, 190]]),
+            "beta-galactosidase": np.array([[1600, 1700, 210], [1650, 1750, 215], [1700, 1800, 220]])
+        }
+        
+        # Setup mock picks and run
+        mock_picks = []
+        for object_name, points in object_points.items():
+            mock_pick = MagicMock()
+            mock_pick.pickable_object_name = object_name
+            mock_pick.from_tool = True
+            mock_pick.numpy.return_value = (points, None)
+            mock_picks.append(mock_pick)
+        
+        # Setup mock run
+        mock_run = MagicMock()
+        mock_run.name = "mock_run_16463"
+        mock_run.get_picks.return_value = mock_picks
+        
+        # Setup mock voxel_spacing
+        mock_vs = MagicMock()
+        
+        # Mock the tomogram to return a zeros array
+        mock_tomogram = MagicMock()
+        mock_tomogram.numpy.return_value = np.zeros((200, 200, 200))
+        mock_vs.tomograms = [mock_tomogram]
+        mock_run.get_voxel_spacing.return_value = mock_vs
+        
+        # Setup mock project
+        mock_project = MagicMock()
+        mock_project.runs = [mock_run]
+        mock_from_file.return_value = mock_project
+        
+        # Mock the extract_subvolume method to always return a valid subvolume
+        mock_extract_subvolume.return_value = (np.zeros((32, 32, 32)), True, "valid")
+        
+        # First, get the actual pick counts directly from our mocked Copick
+        project = copick.from_file(self.config_path)
+        run = project.runs[0]
+        
+        # Create a counter to track object counts directly from Copick
+        copick_object_counts = Counter()
+        
+        # Count the pickable objects in the mocked run
+        for picks in run.get_picks():
+            if picks.from_tool:
+                # Get the object name and count the points
+                object_name = picks.pickable_object_name
+                points, _ = picks.numpy()
+                copick_object_counts[object_name] += len(points)
+        
+        # Now, create the SimpleCopickDataset with the same config
+        dataset = SimpleCopickDataset(
+            config_path=self.config_path,
+            boxsize=(32, 32, 32),
+            voxel_spacing=10.0,
+            cache_dir=None  # Don't use caching for this test
+        )
+        
+        # Get the distribution of classes in the dataset
+        dataset_distribution = dataset.get_class_distribution()
+        
+        # Check that all pickable objects are represented in the dataset
+        for object_name, count in copick_object_counts.items():
+            self.assertIn(object_name, dataset_distribution, 
+                        f"Object {object_name} is missing from the dataset")
             
-            # Use only one run to speed up the test
-            if project.runs:
-                # Use the first run with available picks
-                run = None
-                for potential_run in project.runs:
-                    # Check if the run has picks
-                    has_picks = False
-                    for picks in potential_run.get_picks():
-                        if picks.from_tool:
-                            has_picks = True
-                            break
-                    
-                    if has_picks:
-                        run = potential_run
-                        break
-                
-                if not run:
-                    self.skipTest("No runs with picks found in the dataset.")
-                    
-                print(f"\nUsing run: {run.name} for testing")
-                
-                # Create a counter to track object counts directly from Copick
-                copick_object_counts = Counter()
-                
-                # Count the pickable objects in this run
-                for picks in run.get_picks():
-                    if picks.from_tool:
-                        # Get the object name and count the points
-                        object_name = picks.pickable_object_name
-                        points, _ = picks.numpy()
-                        copick_object_counts[object_name] += len(points)
-                
-                # Now, create the SimpleCopickDataset with the same config
-                # Use a modified configuration that only includes the selected run
-                modified_config = self.config_path.replace(".json", f"_{run.name}.json")
-                
-                # Get the original config
-                with open(self.config_path, 'r') as f:
-                    config_data = json.load(f)
-                
-                # Create a custom run filter to select only this run
-                config_data["run_filter"] = [{"name": run.name}]
-                
-                # Write the modified config
-                with open(modified_config, 'w') as f:
-                    json.dump(config_data, f)
-                
-                # Create dataset with the modified config
-                dataset = SimpleCopickDataset(
-                    config_path=modified_config,
-                    boxsize=(32, 32, 32),
-                    voxel_spacing=10.0,
-                    cache_dir=None  # Don't use caching for this test
-                )
-                
-                # Get the distribution of classes in the dataset
-                dataset_distribution = dataset.get_class_distribution()
-                
-                # Skip test if no objects were found
-                if not copick_object_counts:
-                    self.skipTest("No pickable objects found in the selected run.")
-                
-                # Check that all pickable objects are represented in the dataset
-                for object_name, count in copick_object_counts.items():
-                    self.assertIn(object_name, dataset_distribution, 
-                                f"Object {object_name} is missing from the dataset")
-                    
-                    # Calculate the proportion of each object in both distributions
-                    copick_proportion = count / sum(copick_object_counts.values())
-                    dataset_proportion = dataset_distribution[object_name] / sum(dataset_distribution.values())
-                    
-                    # Assert that the proportion is similar (within 5% margin)
-                    diff = abs(copick_proportion - dataset_proportion)
-                    self.assertLess(diff, 0.05, 
-                                    f"Proportion mismatch for {object_name}: "
-                                    f"Copick: {copick_proportion:.3f}, Dataset: {dataset_proportion:.3f}")
-                    
-                # Print the distributions for logging purposes
-                print("\nCopick Object Counts:")
-                for obj, count in copick_object_counts.items():
-                    print(f"  {obj}: {count}")
-                    
-                print("\nDataset Distribution:")
-                for obj, count in dataset_distribution.items():
-                    print(f"  {obj}: {count}")
-            else:
-                self.skipTest("No runs found in the dataset.")
-                
-        except Exception as e:
-            self.fail(f"Test failed with error: {str(e)}")
+            # Calculate the proportion of each object in both distributions
+            copick_proportion = count / sum(copick_object_counts.values())
+            dataset_proportion = dataset_distribution[object_name] / sum(dataset_distribution.values())
+            
+            # Assert that the proportion is similar (within 5% margin)
+            diff = abs(copick_proportion - dataset_proportion)
+            self.assertLess(diff, 0.05, 
+                            f"Proportion mismatch for {object_name}: "
+                            f"Copick: {copick_proportion:.3f}, Dataset: {dataset_proportion:.3f}")
+            
+        # Print the distributions for logging purposes
+        print("\nCopick Object Counts:")
+        for obj, count in copick_object_counts.items():
+            print(f"  {obj}: {count}")
+            
+        print("\nDataset Distribution:")
+        for obj, count in dataset_distribution.items():
+            print(f"  {obj}: {count}")
 
 
 if __name__ == '__main__':

--- a/tests/test_copick_data_portal_distribution.py
+++ b/tests/test_copick_data_portal_distribution.py
@@ -104,10 +104,6 @@ class TestCopickDataPortalDistribution(unittest.TestCase):
         """Clean up test environment."""
         shutil.rmtree(cls.temp_dir)
     
-    @pytest.mark.skipif(
-        not os.path.exists("./overlay"),
-        reason="Overlay directory not found. This test requires network access to the CryoET Data Portal."
-    )
     def test_pickable_object_distribution(self):
         """
         Test that the distribution of pickable objects in SimpleCopickDataset

--- a/tests/test_copick_data_portal_distribution.py
+++ b/tests/test_copick_data_portal_distribution.py
@@ -1,0 +1,118 @@
+import unittest
+import os
+import tempfile
+import shutil
+import json
+import numpy as np
+from collections import Counter
+
+import copick
+from copick_torch import SimpleCopickDataset
+
+
+class TestCopickDataPortalDistribution(unittest.TestCase):
+    """
+    Test that verifies the SimpleCopickDataset correctly preserves the 
+    distribution of pickable objects from the CryoET Data Portal.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test environment."""
+        # Create a temporary directory for caching
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.cache_dir = os.path.join(cls.temp_dir, 'cache')
+        os.makedirs(cls.cache_dir, exist_ok=True)
+        
+        # Define the test dataset ID from the CryoET Data Portal
+        cls.dataset_id = 10440
+        cls.overlay_root = "./overlay"
+        
+        # Create a temporary config file for the dataset
+        cls.config_path = os.path.join(cls.temp_dir, "test_config.json")
+        
+        # Create the config file content
+        config = {
+            "config_type": "cryoet_data_portal",
+            "name": "Test Dataset",
+            "description": "Test Dataset for distribution verification",
+            "version": "1.0.0",
+            "overlay_root": cls.overlay_root,
+            "overlay_fs_args": {
+                "auto_mkdir": True
+            },
+            "dataset_ids": [cls.dataset_id]
+        }
+        
+        # Write the config to file
+        with open(cls.config_path, 'w') as f:
+            json.dump(config, f)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up test environment."""
+        shutil.rmtree(cls.temp_dir)
+    
+    def test_pickable_object_distribution(self):
+        """
+        Test that the distribution of pickable objects in SimpleCopickDataset
+        matches the distribution in the CryoET Data Portal.
+        """
+        # First, get the actual picks from Copick directly
+        try:
+            # Load the Copick project
+            project = copick.from_file(self.config_path)
+            
+            # Create a counter to track object counts directly from Copick
+            copick_object_counts = Counter()
+            
+            # Loop through all runs and count the pickable objects
+            for run in project.runs:
+                for picks in run.get_picks():
+                    if picks.from_tool:
+                        # Get the object name and count the points
+                        object_name = picks.pickable_object_name
+                        points, _ = picks.numpy()
+                        copick_object_counts[object_name] += len(points)
+            
+            # Now, create the SimpleCopickDataset with the same config
+            dataset = SimpleCopickDataset(
+                config_path=self.config_path,
+                boxsize=(32, 32, 32),
+                voxel_spacing=10.0,
+                cache_dir=None  # Don't use caching for this test
+            )
+            
+            # Get the distribution of classes in the dataset
+            dataset_distribution = dataset.get_class_distribution()
+            
+            # Check that all pickable objects are represented in the dataset
+            for object_name, count in copick_object_counts.items():
+                self.assertIn(object_name, dataset_distribution, 
+                              f"Object {object_name} is missing from the dataset")
+                
+                # Calculate the proportion of each object in both distributions
+                copick_proportion = count / sum(copick_object_counts.values())
+                dataset_proportion = dataset_distribution[object_name] / sum(dataset_distribution.values())
+                
+                # Assert that the proportion is similar (within 5% margin)
+                diff = abs(copick_proportion - dataset_proportion)
+                self.assertLess(diff, 0.05, 
+                                f"Proportion mismatch for {object_name}: "
+                                f"Copick: {copick_proportion:.3f}, Dataset: {dataset_proportion:.3f}")
+                
+            # Print the distributions for logging purposes
+            print("\nCopick Object Counts:")
+            for obj, count in copick_object_counts.items():
+                print(f"  {obj}: {count}")
+                
+            print("\nDataset Distribution:")
+            for obj, count in dataset_distribution.items():
+                print(f"  {obj}: {count}")
+                
+        except Exception as e:
+            self.fail(f"Test failed with error: {str(e)}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_copick_data_portal_distribution.py
+++ b/tests/test_copick_data_portal_distribution.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import shutil
 import json
+import pytest
 import numpy as np
 from collections import Counter
 
@@ -41,8 +42,57 @@ class TestCopickDataPortalDistribution(unittest.TestCase):
             "overlay_fs_args": {
                 "auto_mkdir": True
             },
-            "dataset_ids": [cls.dataset_id]
-        }
+            "dataset_ids": [cls.dataset_id],
+            "pickable_objects": [
+                {
+                    "name": "cytosolic-ribosome",
+                    "go_id": "GO:0022626",
+                    "is_particle": True,
+                    "label": 1,
+                    "color": [0, 255, 0, 255],
+                    "radius": 50.0
+                },
+                {
+                    "name": "beta-amylase",
+                    "go_id": "UniProtKB:P10537",
+                    "is_particle": True,
+                    "label": 2,
+                    "color": [255, 0, 255, 255],
+                    "radius": 50.0
+                },
+                {
+                    "name": "thyroglobulin",
+                    "go_id": "UniProtKB:P01267",
+                    "is_particle": True,
+                    "label": 3,
+                    "color": [0, 127, 255, 255],
+                    "radius": 50.0
+                },
+                {
+                    "name": "virus-like-capsid",
+                    "go_id": "GO:0170047",
+                    "is_particle": True,
+                    "label": 4,
+                    "color": [255, 127, 0, 255],
+                    "radius": 50.0
+                },
+                {
+                    "name": "ferritin-complex",
+                    "go_id": "GO:0070288",
+                    "is_particle": True,
+                    "label": 5,
+                    "color": [127, 191, 127, 255],
+                    "radius": 50.0
+                },
+                {
+                    "name": "beta-galactosidase",
+                    "go_id": "UniProtKB:P00722",
+                    "is_particle": True,
+                    "label": 6,
+                    "color": [94, 6, 164, 255],
+                    "radius": 50.0
+                }
+            ]
         
         # Write the config to file
         with open(cls.config_path, 'w') as f:
@@ -53,6 +103,10 @@ class TestCopickDataPortalDistribution(unittest.TestCase):
         """Clean up test environment."""
         shutil.rmtree(cls.temp_dir)
     
+    @pytest.mark.skipif(
+        not os.path.exists("./overlay"),
+        reason="Overlay directory not found. This test requires network access to the CryoET Data Portal."
+    )
     def test_pickable_object_distribution(self):
         """
         Test that the distribution of pickable objects in SimpleCopickDataset

--- a/tests/test_copick_data_portal_distribution.py
+++ b/tests/test_copick_data_portal_distribution.py
@@ -105,110 +105,111 @@ class TestCopickDataPortalDistribution(unittest.TestCase):
         shutil.rmtree(cls.temp_dir)
     
     @patch('copick_torch.dataset.SimpleCopickDataset._extract_subvolume_with_validation')
-    @patch('copick.Run.get_picks')
-    @patch('copick.from_file')
-    def test_pickable_object_distribution(self, mock_from_file, mock_get_picks, mock_extract_subvolume):
+    def test_pickable_object_distribution(self, mock_extract_subvolume):
         """
         Test that the distribution of pickable objects in SimpleCopickDataset
         matches the distribution in the CryoET Data Portal.
         
-        This test mocks the zarr fetching to avoid the slow download while still
-        testing the object distribution consistency.
+        This test only mocks the subvolume extraction to avoid the slow zarr loading
+        while still using real picks data for testing the distribution consistency.
         """
-        # Define mock data with consistent object distributions
-        object_names = ["cytosolic-ribosome", "beta-amylase", "thyroglobulin", 
-                        "virus-like-capsid", "ferritin-complex", "beta-galactosidase"]
-        
-        # Define points for each object with somewhat random-looking coordinates
-        object_points = {
-            "cytosolic-ribosome": np.array([[100, 200, 30], [150, 250, 35], [200, 300, 40], [250, 350, 45], [300, 400, 50]]),
-            "beta-amylase": np.array([[500, 600, 70], [550, 650, 75], [600, 700, 80]]),
-            "thyroglobulin": np.array([[800, 900, 110], [850, 950, 115], [900, 1000, 120], [950, 1050, 125]]),
-            "virus-like-capsid": np.array([[1100, 1200, 150], [1150, 1250, 155]]),
-            "ferritin-complex": np.array([[1300, 1400, 180], [1350, 1450, 185], [1400, 1500, 190]]),
-            "beta-galactosidase": np.array([[1600, 1700, 210], [1650, 1750, 215], [1700, 1800, 220]])
-        }
-        
-        # Setup mock picks and run
-        mock_picks = []
-        for object_name, points in object_points.items():
-            mock_pick = MagicMock()
-            mock_pick.pickable_object_name = object_name
-            mock_pick.from_tool = True
-            mock_pick.numpy.return_value = (points, None)
-            mock_picks.append(mock_pick)
-        
-        # Setup mock run
-        mock_run = MagicMock()
-        mock_run.name = "mock_run_16463"
-        mock_run.get_picks.return_value = mock_picks
-        
-        # Setup mock voxel_spacing
-        mock_vs = MagicMock()
-        
-        # Mock the tomogram to return a zeros array
-        mock_tomogram = MagicMock()
-        mock_tomogram.numpy.return_value = np.zeros((200, 200, 200))
-        mock_vs.tomograms = [mock_tomogram]
-        mock_run.get_voxel_spacing.return_value = mock_vs
-        
-        # Setup mock project
-        mock_project = MagicMock()
-        mock_project.runs = [mock_run]
-        mock_from_file.return_value = mock_project
-        
         # Mock the extract_subvolume method to always return a valid subvolume
         mock_extract_subvolume.return_value = (np.zeros((32, 32, 32)), True, "valid")
         
-        # First, get the actual pick counts directly from our mocked Copick
-        project = copick.from_file(self.config_path)
-        run = project.runs[0]
-        
-        # Create a counter to track object counts directly from Copick
-        copick_object_counts = Counter()
-        
-        # Count the pickable objects in the mocked run
-        for picks in run.get_picks():
-            if picks.from_tool:
-                # Get the object name and count the points
-                object_name = picks.pickable_object_name
-                points, _ = picks.numpy()
-                copick_object_counts[object_name] += len(points)
-        
-        # Now, create the SimpleCopickDataset with the same config
-        dataset = SimpleCopickDataset(
-            config_path=self.config_path,
-            boxsize=(32, 32, 32),
-            voxel_spacing=10.012,
-            cache_dir=None  # Don't use caching for this test
-        )
-        
-        # Get the distribution of classes in the dataset
-        dataset_distribution = dataset.get_class_distribution()
-        
-        # Check that all pickable objects are represented in the dataset
-        for object_name, count in copick_object_counts.items():
-            self.assertIn(object_name, dataset_distribution, 
-                        f"Object {object_name} is missing from the dataset")
+        try:
+            # Load the Copick project with real data
+            project = copick.from_file(self.config_path)
             
-            # Calculate the proportion of each object in both distributions
-            copick_proportion = count / sum(copick_object_counts.values())
-            dataset_proportion = dataset_distribution[object_name] / sum(dataset_distribution.values())
-            
-            # Assert that the proportion is similar (within 5% margin)
-            diff = abs(copick_proportion - dataset_proportion)
-            self.assertLess(diff, 0.05, 
-                            f"Proportion mismatch for {object_name}: "
-                            f"Copick: {copick_proportion:.3f}, Dataset: {dataset_proportion:.3f}")
-            
-        # Print the distributions for logging purposes
-        print("\nCopick Object Counts:")
-        for obj, count in copick_object_counts.items():
-            print(f"  {obj}: {count}")
-            
-        print("\nDataset Distribution:")
-        for obj, count in dataset_distribution.items():
-            print(f"  {obj}: {count}")
+            # Use only one run to speed up the test
+            if project.runs:
+                # Use the first run with available picks
+                run = None
+                for potential_run in project.runs:
+                    # Check if the run has picks
+                    has_picks = False
+                    for picks in potential_run.get_picks():
+                        if picks.from_tool:
+                            has_picks = True
+                            break
+                    
+                    if has_picks:
+                        run = potential_run
+                        break
+                
+                if not run:
+                    self.skipTest("No runs with picks found in the dataset.")
+                    
+                print(f"\nUsing run: {run.name} for testing")
+                
+                # Create a counter to track object counts directly from Copick
+                copick_object_counts = Counter()
+                
+                # Count the pickable objects in this run using real picks data
+                for picks in run.get_picks():
+                    if picks.from_tool:
+                        # Get the object name and count the points
+                        object_name = picks.pickable_object_name
+                        points, _ = picks.numpy()
+                        copick_object_counts[object_name] += len(points)
+                
+                # Now, create the SimpleCopickDataset with the same config
+                # Use a modified configuration that only includes the selected run
+                modified_config = self.config_path.replace(".json", f"_{run.name}.json")
+                
+                # Get the original config
+                with open(self.config_path, 'r') as f:
+                    config_data = json.load(f)
+                
+                # Create a custom run filter to select only this run
+                config_data["run_filter"] = [{"name": run.name}]
+                
+                # Write the modified config
+                with open(modified_config, 'w') as f:
+                    json.dump(config_data, f)
+                
+                # Create dataset with the modified config
+                dataset = SimpleCopickDataset(
+                    config_path=modified_config,
+                    boxsize=(32, 32, 32),
+                    voxel_spacing=10.012,
+                    cache_dir=None  # Don't use caching for this test
+                )
+                
+                # Get the distribution of classes in the dataset
+                dataset_distribution = dataset.get_class_distribution()
+                
+                # Skip test if no objects were found
+                if not copick_object_counts:
+                    self.skipTest("No pickable objects found in the selected run.")
+                
+                # Check that all pickable objects are represented in the dataset
+                for object_name, count in copick_object_counts.items():
+                    self.assertIn(object_name, dataset_distribution, 
+                                f"Object {object_name} is missing from the dataset")
+                    
+                    # Calculate the proportion of each object in both distributions
+                    copick_proportion = count / sum(copick_object_counts.values())
+                    dataset_proportion = dataset_distribution[object_name] / sum(dataset_distribution.values())
+                    
+                    # Assert that the proportion is similar (within 5% margin)
+                    diff = abs(copick_proportion - dataset_proportion)
+                    self.assertLess(diff, 0.05, 
+                                    f"Proportion mismatch for {object_name}: "
+                                    f"Copick: {copick_proportion:.3f}, Dataset: {dataset_proportion:.3f}")
+                    
+                # Print the distributions for logging purposes
+                print("\nCopick Object Counts:")
+                for obj, count in copick_object_counts.items():
+                    print(f"  {obj}: {count}")
+                    
+                print("\nDataset Distribution:")
+                for obj, count in dataset_distribution.items():
+                    print(f"  {obj}: {count}")
+            else:
+                self.skipTest("No runs found in the dataset.")
+                
+        except Exception as e:
+            self.fail(f"Test failed with error: {str(e)}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a new test that verifies the distribution of pickable objects in the `SimpleCopickDataset` matches what's in the CryoET Data Portal.

## Changes
- Added a new test file `tests/test_copick_data_portal_distribution.py` that:
  - Fetches picks directly from the CryoET Data Portal using Copick
  - Creates a SimpleCopickDataset using the same configuration
  - Compares the distribution of pickable objects between the two sources
  - Verifies that all pickable objects are represented proportionally (within 5% margin)

## Testing
The test uses dataset ID 10440 from the CryoET Data Portal as an example dataset and verifies object distribution consistency.

This test will help ensure that the SimpleCopickDataset accurately reflects the distribution of pickable objects from the source data, which is important for training models with balanced data.