### PR TITLE
Add citation information to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ Torch utilities for [copick](https://github.com/copick/copick)
 
 `uv run examples/simple_training.py`
 
+## Citation
+
+If you use `copick-torch` in your research, please cite:
+
+```bibtex
+@article{harrington2024open,
+  title={Open-source Tools for CryoET Particle Picking Machine Learning Competitions},
+  author={Harrington, Kyle I. and Zhao, Zhuowen and Schwartz, Jonathan and Kandel, Saugat and Ermel, Utz and Paraan, Mohammadreza and Potter, Clinton and Carragher, Bridget},
+  journal={bioRxiv},
+  year={2024},
+  doi={10.1101/2024.11.04.621608}
+}
+```
+
+This software was introduced in a NeurIPS 2024 Workshop on Machine Learning in Structural Biology as "Open-source Tools for CryoET Particle Picking Machine Learning Competitions".
+
 ## Development
 
 ### Install development dependencies


### PR DESCRIPTION
This PR adds a citation section to the README.md file for properly citing the work that introduced copick-torch.

The citation references the paper "Open-source Tools for CryoET Particle Picking Machine Learning Competitions" by Harrington et al., which was presented at the NeurIPS 2024 Workshop on Machine Learning in Structural Biology and is available as a preprint on bioRxiv (doi: 10.1101/2024.11.04.621608).

This helps ensure that the project receives proper academic attribution when used in research.