### PR TITLE
Replace slow SimpleCopickDataset with faster MinimalCopickDataset for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ uv run examples/spliced_mixup_fourier_example.py
 # Generate augmentation documentation
 python scripts/generate_augmentation_docs.py
 
-# Generate dataset documentation (both SimpleCopickDataset and MinimalCopickDataset)
-python scripts/generate_simple_dataset_docs.py
+# Generate dataset documentation
+python scripts/generate_dataset_examples.py
 ```
 
 ## Features
@@ -105,8 +105,7 @@ augmented_volume = fourier_aug(volume_tensor)
 See the [docs directory](./docs) for documentation and examples:
 
 - [Augmentation Examples](./docs/augmentation_examples): Visualizations of various augmentations applied to different classes from the dataset used in the `spliced_mixup_example.py` example.
-- [Simple Dataset Examples](./docs/simple_dataset_examples): Examples of volumes from each class in the dataset used by the `SimpleCopickDataset` class.
-- [Minimal Dataset Examples](./docs/minimal_dataset_examples): Examples of volumes from each class in the dataset used by the `MinimalCopickDataset` class.
+- [Dataset Examples](./docs/dataset_examples): Examples of volumes from each class in the dataset used by the CopickDataset classes.
 
 ## Citation
 

--- a/scripts/generate_dataset_examples.py
+++ b/scripts/generate_dataset_examples.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+"""
+Script to generate documentation examples for the MinimalCopickDataset class.
+
+This script creates a MinimalCopickDataset instance with limited examples for each class
+using the experimental dataset ID 10440, then saves an example volume from each class
+to provide a visual reference of the dataset contents.
+"""
+
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+import os
+import random
+import copick
+import logging
+import time
+
+# Import necessary classes
+from copick_torch import MinimalCopickDataset, setup_logging
+
+# Set random seeds for reproducibility
+SEED = 42
+random.seed(SEED)
+np.random.seed(SEED)
+torch.manual_seed(SEED)
+if torch.cuda.is_available():
+    torch.cuda.manual_seed(SEED)
+
+def visualize_volume(volume, title, output_path, cmap='gray'):
+    """
+    Visualize a volume with central slice and sum projection views.
+    
+    Args:
+        volume: 3D volume (torch tensor with shape [C, D, H, W] or numpy array with shape [D, H, W])
+        title: Title for the plot
+        output_path: Path to save the visualization
+        cmap: Colormap to use for visualization
+    """
+    # Ensure we have a numpy array in the right shape
+    if isinstance(volume, torch.Tensor):
+        if volume.dim() == 4:  # [C, D, H, W]
+            volume = volume.squeeze(0).numpy()
+        else:  # [D, H, W]
+            volume = volume.numpy()
+    
+    fig, axes = plt.subplots(2, 3, figsize=(15, 10))
+    fig.suptitle(title, fontsize=16)
+    
+    # Get dimensions
+    depth, height, width = volume.shape
+    
+    # Central slices
+    z_slice = depth // 2
+    y_slice = height // 2
+    x_slice = width // 2
+    
+    # Central slice views
+    axes[0, 0].imshow(volume[z_slice, :, :], cmap=cmap)
+    axes[0, 0].set_title(f"XY Plane (Z={z_slice})")
+    axes[0, 0].axis('off')
+    
+    axes[0, 1].imshow(volume[:, y_slice, :], cmap=cmap)
+    axes[0, 1].set_title(f"XZ Plane (Y={y_slice})")
+    axes[0, 1].axis('off')
+    
+    axes[0, 2].imshow(volume[:, :, x_slice], cmap=cmap)
+    axes[0, 2].set_title(f"YZ Plane (X={x_slice})")
+    axes[0, 2].axis('off')
+    
+    # Sum projections
+    axes[1, 0].imshow(np.sum(volume, axis=0), cmap=cmap)
+    axes[1, 0].set_title("XY Sum Projection")
+    axes[1, 0].axis('off')
+    
+    axes[1, 1].imshow(np.sum(volume, axis=1), cmap=cmap)
+    axes[1, 1].set_title("XZ Sum Projection")
+    axes[1, 1].axis('off')
+    
+    axes[1, 2].imshow(np.sum(volume, axis=2), cmap=cmap)
+    axes[1, 2].set_title("YZ Sum Projection")
+    axes[1, 2].axis('off')
+    
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches='tight')
+    plt.close(fig)
+
+def get_pickable_objects_from_dataset(dataset_id, overlay_root="/tmp/test/"):
+    """
+    Get the pickable objects directly from the dataset.
+    
+    Args:
+        dataset_id: Dataset ID to query
+        overlay_root: The overlay root directory
+        
+    Returns:
+        A list of pickable object names
+    """
+    try:
+        # Create a temporary copick root object
+        copick_root = copick.from_czcdp_datasets([dataset_id], overlay_root=overlay_root)
+        
+        # Get pickable objects
+        pickable_objects = copick_root.pickable_objects
+        
+        # Extract names
+        object_names = [obj.name for obj in pickable_objects]
+        print(f"Found pickable objects: {object_names}")
+        
+        return object_names
+    except Exception as e:
+        print(f"Error getting pickable objects: {e}")
+        return []
+
+
+def collect_examples_from_dataset(dataset, include_background=True, max_examples=1):
+    """
+    Collect examples from the dataset for each class.
+    
+    Args:
+        dataset: Dataset to collect examples from
+        include_background: Whether to include background class
+        max_examples: Maximum number of examples to collect per class (for efficiency)
+        
+    Returns:
+        Dictionary mapping class names to example volumes
+    """
+    print("Collecting examples from dataset...")
+    examples = {}
+    class_indices = {class_name: [] for class_name in dataset.keys()}
+    
+    # Initialize counters for each class
+    class_counts = {class_name: 0 for class_name in dataset.keys()}
+    max_samples_reached = False
+    
+    # Collect indices by class
+    print("Scanning dataset for examples...")
+    for i in range(len(dataset)):
+        # Check if we've collected enough examples for each class
+        if max_samples_reached:
+            break
+            
+        volume, label = dataset[i]
+        
+        # Get class name from label
+        if label == -1:
+            class_name = "background"
+            if not include_background:
+                continue
+        else:
+            try:
+                # Make sure we're within bounds
+                if label < len(dataset.keys()):
+                    class_name = dataset.keys()[label]
+                else:
+                    print(f"WARNING: Label {label} is out of bounds for dataset keys. Skipping.")
+                    continue
+            except Exception as e:
+                print(f"Error getting class name for label {label}: {e}")
+                continue
+        
+        # If we already have enough examples for this class, skip
+        if class_counts.get(class_name, 0) >= max_examples:
+            continue
+            
+        # Store the index by class name
+        class_indices[class_name].append(i)
+        class_counts[class_name] += 1
+        
+        # Check if we've collected enough examples for all classes
+        max_samples_reached = all(count >= max_examples for count in class_counts.values())
+        if max_samples_reached:
+            print(f"Collected {max_examples} examples for each class. Stopping scan.")
+    
+    # Get examples from the indices
+    for class_name, indices in class_indices.items():
+        if indices:
+            # Choose a random index
+            idx = random.choice(indices)
+            volume, _ = dataset[idx]
+            examples[class_name] = volume
+            print(f"  Added example for {class_name}")
+    
+    return examples
+
+
+def main():
+    """Main function to generate the documentation."""
+    start_time = time.time()
+    
+    # Set up logging
+    setup_logging(level=logging.INFO)
+    
+    # Create output directory
+    output_dir = Path("docs/dataset_examples")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Create markdown file
+    md_file = output_dir / "README.md"
+    
+    # Get pickable objects directly from the dataset first
+    dataset_id = 10440  # Experimental dataset ID
+    overlay_root = "/tmp/test/"
+    pickable_objects = get_pickable_objects_from_dataset(dataset_id, overlay_root)
+
+    # Create MinimalCopickDataset with a very small max_samples value for efficiency
+    print("\nLoading MinimalCopickDataset...")
+    dataset = MinimalCopickDataset(
+        dataset_id=dataset_id,           # Experimental dataset ID
+        overlay_root=overlay_root,       # Overlay root directory
+        boxsize=(48, 48, 48),            # Size of the subvolumes
+        voxel_spacing=10.012,            # Voxel spacing
+        include_background=True,         # Include background samples
+        background_ratio=0.2,            # Background ratio
+        min_background_distance=48,      # Minimum distance from particles for background
+        max_samples=50                   # Limit samples for faster processing
+    )
+
+    # Print dataset information
+    print(f"Dataset size: {len(dataset)}")
+    print(f"Classes: {dataset.keys()}")
+    
+    # Show class distribution
+    distribution = dataset.get_class_distribution()
+    print("\nClass Distribution:")
+    for class_name, count in distribution.items():
+        print(f"  {class_name}: {count} samples")
+    
+    # Collect a single example for each class for efficiency
+    examples = collect_examples_from_dataset(dataset, max_examples=1)
+    
+    # Generate examples for the dataset
+    print("\nGenerating examples for dataset...")
+    with open(md_file, 'w') as f:
+        f.write("# CopickDataset Examples\n\n")
+        f.write("This document shows examples of volumes from each class in the dataset used by the `MinimalCopickDataset` class.\n\n")
+        f.write("The visualizations show both central slices (top row) and sum projections (bottom row) in XY, XZ, and YZ planes.\n\n")
+        
+        # Process each class
+        for class_name, volume in examples.items():
+            print(f"Processing class: {class_name}")
+            
+            # Create filename - ensure it exactly matches the class name
+            filename = f"{class_name.lower().replace(' ', '_').replace('-', '_')}.png"
+            filepath = output_dir / filename
+            
+            # Normalize for visualization
+            if isinstance(volume, torch.Tensor):
+                vis_volume = volume.squeeze(0)
+                if torch.std(vis_volume) > 0:
+                    vis_volume = (vis_volume - torch.mean(vis_volume)) / torch.std(vis_volume)
+                vis_volume = vis_volume.numpy()
+            else:
+                if np.std(volume) > 0:
+                    vis_volume = (volume - np.mean(volume)) / np.std(volume)
+                else:
+                    vis_volume = volume
+            
+            # Visualize and save
+            visualize_volume(vis_volume, f"Class: {class_name}", filepath)
+            
+            # Add to markdown
+            f.write(f"## Class: {class_name}\n\n")
+            f.write(f"![{class_name}](./{filename})\n\n")
+        
+        # Add information about the dataset
+        f.write("## Dataset Information\n\n")
+        f.write("The dataset used in this example is created using the `MinimalCopickDataset` class with the following parameters:\n\n")
+        f.write("```python\n")
+        f.write("dataset = MinimalCopickDataset(\n")
+        f.write("    dataset_id=10440,          # Experimental dataset ID\n")
+        f.write("    overlay_root='/tmp/test/', # Overlay root directory\n")
+        f.write("    boxsize=(48, 48, 48),      # Size of the subvolumes\n")
+        f.write("    voxel_spacing=10.012,      # Voxel spacing\n")
+        f.write("    include_background=True,   # Include background samples\n")
+        f.write("    background_ratio=0.2,      # Background ratio\n")
+        f.write("    min_background_distance=48,# Minimum distance from particles for background\n")
+        f.write(")\n")
+        f.write("```\n\n")
+        
+        # Add class distribution information
+        f.write("### Class Distribution\n\n")
+        f.write("| Class | Count |\n")
+        f.write("|-------|-------|\n")
+        for class_name, count in distribution.items():
+            f.write(f"| {class_name} | {count} |\n")
+    
+    end_time = time.time()
+    print(f"\nDocumentation generated successfully in {end_time - start_time:.2f} seconds.")
+    print(f"Examples saved to {output_dir}")
+    print(f"Markdown file saved to {md_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dataset_examples.py
+++ b/tests/test_dataset_examples.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+"""
+Test script to ensure that class names match filenames in the dataset examples.
+"""
+
+import unittest
+import os
+import re
+import tempfile
+import shutil
+import sys
+import zarr
+import numpy as np
+import random
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add the script directory to the path to import generate_dataset_examples
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+
+class TestDatasetExamples(unittest.TestCase):
+    """
+    Test class to verify the correct relationship between class names and file names
+    in the dataset_examples documentation.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up a temporary directory for testing."""
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.docs_dir = os.path.join(cls.temp_dir, 'docs')
+        os.makedirs(cls.docs_dir, exist_ok=True)
+        
+        # Copy the original script output path to a backup
+        cls.original_docs_dir = Path("docs/dataset_examples")
+        if cls.original_docs_dir.exists():
+            cls.backup_dir = Path(tempfile.mkdtemp())
+            shutil.copytree(cls.original_docs_dir, cls.backup_dir / "dataset_examples")
+            print(f"Backed up original docs to {cls.backup_dir}")
+        else:
+            cls.backup_dir = None
+            
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up the temporary directory."""
+        shutil.rmtree(cls.temp_dir)
+        
+        # Restore the original docs if they were backed up
+        if cls.backup_dir and cls.original_docs_dir.exists():
+            shutil.rmtree(cls.original_docs_dir)
+            shutil.copytree(cls.backup_dir / "dataset_examples", cls.original_docs_dir)
+            shutil.rmtree(cls.backup_dir)
+            print(f"Restored original docs")
+    
+    @patch('zarr.open')
+    @patch('copick.from_czcdp_datasets')
+    def test_class_name_to_filename_consistency(self, mock_from_czcdp, mock_zarr_open):
+        """
+        Test that each class name in the markdown file correctly corresponds to a matching
+        filename in the directory.
+        
+        The test patches the output directory and then run the generate_docs function
+        with mocked dependencies to avoid actual copick operations.
+        """
+        # Set up mock for copick.from_czcdp_datasets
+        mock_copick_root = MagicMock()
+        mock_run = MagicMock()
+        mock_vs = MagicMock()
+        mock_tomogram = MagicMock()
+        mock_picks = MagicMock()
+        mock_po = MagicMock()
+        
+        # Configure mocks
+        mock_from_czcdp.return_value = mock_copick_root
+        mock_copick_root.runs = [mock_run]
+        mock_copick_root.pickable_objects = [
+            MagicMock(name="ferritin-complex"),
+            MagicMock(name="virus-like-capsid"),
+            MagicMock(name="cytosolic-ribosome"),
+            MagicMock(name="membrane"),
+            MagicMock(name="beta-galactosidase"),
+            MagicMock(name="beta-amylase"),
+            MagicMock(name="thyroglobulin")
+        ]
+        for po in mock_copick_root.pickable_objects:
+            po.name = po.name
+            
+        mock_run.name = "test_run"
+        mock_run.get_voxel_spacing.return_value = mock_vs
+        mock_vs.tomograms = [mock_tomogram]
+        mock_tomogram.tomo_type = "wbp-denoised"
+        
+        # Mock picks for each object type
+        mock_picks_list = []
+        for po in mock_copick_root.pickable_objects:
+            mock_pick = MagicMock()
+            mock_pick.from_tool = True
+            mock_pick.pickable_object_name = po.name
+            mock_pick.numpy.return_value = (np.array([[100, 100, 100]]), None)
+            mock_picks_list.append(mock_pick)
+        
+        mock_run.get_picks.return_value = mock_picks_list
+        
+        # Mock zarr.open to return a dummy array
+        mock_zarr_root = MagicMock()
+        mock_zarr_open.return_value = mock_zarr_root
+        mock_zarr_root.__getitem__.return_value = np.random.randn(100, 100, 100)
+        mock_tomogram.zarr.return_value = "dummy_zarr_path"
+        
+        # We'll patch the output directory and then run the generate_docs function
+        original_output_dir = Path("docs/dataset_examples")
+        temp_output_dir = Path(self.docs_dir) / "dataset_examples"
+
+        # Monkey patch the Path class to redirect the output
+        original_init = Path.__init__
+        
+        def patched_init(self_path, *args, **kwargs):
+            # Replace the output directory path with our temp directory
+            arg_str = str(args[0]) if args else ""
+            if arg_str == str(original_output_dir):
+                original_init(self_path, temp_output_dir, **kwargs)
+            else:
+                original_init(self_path, *args, **kwargs)
+        
+        # Apply monkey patch
+        Path.__init__ = patched_init
+        
+        try:
+            # Run the document generation script
+            from generate_dataset_examples import main as generate_docs
+            generate_docs()
+            
+            # Verify the markdown file exists
+            md_file = temp_output_dir / "README.md"
+            self.assertTrue(md_file.exists(), f"README.md file not found at {md_file}")
+            
+            # Read the markdown file
+            with open(md_file, 'r') as f:
+                content = f.read()
+            
+            # Extract all class names and filenames
+            class_pattern = re.compile(r'## Class: ([^\n]+)')
+            image_pattern = re.compile(r'!\[(.*?)\]\(\./([^)]+)\)')
+            
+            class_names = class_pattern.findall(content)
+            image_refs = image_pattern.findall(content)
+            
+            # Check that all class sections have a corresponding image
+            self.assertEqual(len(class_names), len(image_refs), 
+                            f"Number of class sections ({len(class_names)}) does not match number of images ({len(image_refs)})")
+            
+            # Check the directory for actual image files
+            image_files = [f for f in os.listdir(temp_output_dir) if f.endswith('.png')]
+            
+            # Check that all referenced images exist in the directory
+            for _, filename in image_refs:
+                self.assertIn(filename, image_files, f"Referenced image file {filename} not found in the directory")
+            
+            # Verify that all class names match their corresponding images
+            for i, class_name in enumerate(class_names):
+                # Get the image reference for this class
+                image_alt, image_file = image_refs[i]
+                
+                # The alt text should match the class name
+                self.assertEqual(class_name, image_alt, 
+                                f"Alt text '{image_alt}' does not match class name '{class_name}'")
+                
+                # Generate the expected filename from the class name
+                expected_filename = f"{class_name.lower().replace(' ', '_').replace('-', '_')}.png"
+                
+                # Check that the actual filename matches the expected filename
+                self.assertEqual(expected_filename, image_file, 
+                                f"Image filename '{image_file}' does not match expected filename '{expected_filename}' for class '{class_name}'")
+                
+                # Verify the file exists with the expected name
+                self.assertTrue((temp_output_dir / image_file).exists(), 
+                                f"Image file {image_file} does not exist")
+            
+            # Check that we have examples for all the expected pickable objects
+            expected_class_names = [po.name for po in mock_copick_root.pickable_objects] + ["background"]
+            for expected_class in expected_class_names:
+                self.assertIn(expected_class, class_names, 
+                            f"Missing example for expected class '{expected_class}'")
+            
+        finally:
+            # Restore the original Path.__init__
+            Path.__init__ = original_init
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

The current `generate_simple_dataset_docs.py` script has several issues:
1. It uses SimpleCopickDataset which is no longer preferred
2. It's very slow due to loading the entire dataset and caching
3. It processes more samples than needed just to generate examples

## Solution

This PR replaces the slow script with a much faster implementation that:

1. **Uses only MinimalCopickDataset**: Removes dependency on SimpleCopickDataset
2. **Limits sample scanning**: Stops processing once it finds examples of each class
3. **Improves efficiency**: Processes only a small fraction of the dataset
4. **Adds timing information**: Reports execution time for performance tracking
5. **Focuses on essentials**: Collects just one example per class for faster processing

## Performance Improvement

The new implementation is significantly faster because it:
- Doesn't load and cache the entire dataset
- Stops scanning after finding enough examples
- Uses a small max_samples value (50) to limit processing
- Avoids processing unnecessary data

## Implementation Details

The changes include:
1. A new `generate_dataset_examples.py` script that replaces `generate_simple_dataset_docs.py`
2. Updated README references to point to the new script and documentation structure
3. A new test file `test_dataset_examples.py` aligned with the new implementation

## Testing

The PR includes an updated test suite that verifies:
- All pickable objects have examples
- Class names match their filenames
- All referenced images exist in the documentation

This implementation fixes the referenced issue while significantly improving the performance of the documentation generation process.