### PR TITLE
Add utility script for saving torch datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Torch utilities for [copick](https://github.com/copick/copick)
 
 ### MinimalCopickDataset Usage
 
+#### Direct usage in Python
+
 ```python
 from copick_torch import MinimalCopickDataset
 from torch.utils.data import DataLoader
@@ -49,6 +51,37 @@ for volume, label in dataloader:
     pass
 ```
 
+#### Saving and loading datasets
+
+The `MinimalCopickDataset` can be saved to disk and loaded later:
+
+```python
+# Save a dataset to disk
+dataset.save('/path/to/save')
+
+# Load a dataset from disk
+loaded_dataset = MinimalCopickDataset.load('/path/to/save')
+```
+
+You can also use the provided utility script to save a dataset directly from the command line:
+
+```bash
+python scripts/save_torch_dataset.py --dataset_id 10440 --output_dir /path/to/save
+```
+
+Options:
+```
+  --dataset_id DATASET_ID   Dataset ID from the CZ cryoET Data Portal
+  --output_dir OUTPUT_DIR   Directory to save the dataset
+  --overlay_root OVERLAY_ROOT
+                            Root directory for overlay storage (default: /tmp/copick_overlay)
+  --boxsize Z Y X           Size of subvolumes to extract (default: 48 48 48)
+  --voxel_spacing SPACING   Voxel spacing to use (default: 10.012)
+  --include_background      Include background samples in the dataset
+  --background_ratio RATIO  Ratio of background to particle samples (default: 0.2)
+  --verbose                 Enable verbose output
+```
+
 ## Quick demo
 
 ```bash
@@ -72,6 +105,9 @@ python scripts/generate_augmentation_docs.py
 
 # Generate dataset documentation
 python scripts/generate_dataset_examples.py
+
+# Save dataset to disk for later use
+python scripts/save_torch_dataset.py --dataset_id 10440 --output_dir /path/to/save
 ```
 
 ## Features

--- a/scripts/save_torch_dataset.py
+++ b/scripts/save_torch_dataset.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""
+Utility script to create and save a MinimalCopickDataset to disk.
+
+Usage:
+    python save_torch_dataset.py --dataset_id 10440 --output_dir /path/to/output
+"""
+
+import argparse
+import logging
+import os
+import copick
+from copick_torch.minimal_dataset import MinimalCopickDataset
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, 
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logger = logging.getLogger(__name__)
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description='Create and save a MinimalCopickDataset to disk')
+    
+    # Required arguments
+    parser.add_argument('--dataset_id', type=int, required=True,
+                        help='Dataset ID from the CZ cryoET Data Portal')
+    parser.add_argument('--output_dir', type=str, required=True,
+                        help='Directory to save the dataset')
+    
+    # Optional arguments
+    parser.add_argument('--overlay_root', type=str, default='/tmp/copick_overlay',
+                        help='Root directory for the overlay storage (default: /tmp/copick_overlay)')
+    parser.add_argument('--boxsize', type=int, nargs=3, default=[48, 48, 48],
+                        help='Size of subvolumes to extract as z y x (default: 48 48 48)')
+    parser.add_argument('--voxel_spacing', type=float, default=10.012,
+                        help='Voxel spacing to use (default: 10.012)')
+    parser.add_argument('--include_background', action='store_true',
+                        help='Include background samples in the dataset')
+    parser.add_argument('--background_ratio', type=float, default=0.2,
+                        help='Ratio of background to particle samples (default: 0.2)')
+    parser.add_argument('--min_background_distance', type=float, default=None,
+                        help='Minimum distance from particles for background (default: max boxsize)')
+    parser.add_argument('--verbose', action='store_true',
+                        help='Enable verbose output')
+    
+    return parser.parse_args()
+
+def main():
+    """Main function to create and save the dataset."""
+    # Parse command line arguments
+    args = parse_args()
+    
+    # Set log level based on verbose flag
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+    
+    # Log the parameters
+    logger.info(f"Creating dataset with the following parameters:")
+    logger.info(f"  Dataset ID: {args.dataset_id}")
+    logger.info(f"  Output directory: {args.output_dir}")
+    logger.info(f"  Overlay root: {args.overlay_root}")
+    logger.info(f"  Box size: {args.boxsize}")
+    logger.info(f"  Voxel spacing: {args.voxel_spacing}")
+    logger.info(f"  Include background: {args.include_background}")
+    logger.info(f"  Background ratio: {args.background_ratio}")
+    logger.info(f"  Min background distance: {args.min_background_distance}")
+    
+    # Create the output directory if it doesn't exist
+    os.makedirs(args.output_dir, exist_ok=True)
+    
+    try:
+        # Load the dataset from CoPICK
+        logger.info(f"Loading dataset {args.dataset_id} from CoPICK...")
+        proj = copick.from_czcdp_datasets([args.dataset_id], overlay_root=args.overlay_root)
+        
+        # Create the dataset
+        logger.info("Creating MinimalCopickDataset...")
+        dataset = MinimalCopickDataset(
+            proj=proj,
+            boxsize=tuple(args.boxsize),
+            voxel_spacing=args.voxel_spacing,
+            include_background=args.include_background,
+            background_ratio=args.background_ratio,
+            min_background_distance=args.min_background_distance
+        )
+        
+        # Save the dataset
+        logger.info(f"Saving dataset to {args.output_dir}...")
+        dataset.save(args.output_dir)
+        
+        # Log completion
+        logger.info(f"Dataset saved successfully with {len(dataset)} samples.")
+        
+        # Print class distribution
+        distribution = dataset.get_class_distribution()
+        logger.info("Class distribution:")
+        for class_name, count in distribution.items():
+            logger.info(f"  {class_name}: {count} samples")
+            
+    except Exception as e:
+        logger.error(f"Error creating or saving dataset: {e}", exc_info=True)
+        return 1
+        
+    return 0
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
This PR adds a utility script that allows users to create and save a MinimalCopickDataset from the command line.

## Features

- New script: `scripts/save_torch_dataset.py` that:
  - Takes a dataset ID and creates a MinimalCopickDataset
  - Saves the dataset to a specified output directory
  - Supports customizing all important dataset parameters

- Command-line usage matches the example in the issue:
  ```bash
  python scripts/save_torch_dataset.py --dataset_id 10440 --output_dir /mnt/czi-sci-ai/imaging-models/data/cryolens/mlc/torch/dataset_10440
  ```

- Full set of configurable options:
  - `--dataset_id`: CZ cryoET Data Portal dataset ID
  - `--output_dir`: Directory to save the dataset
  - `--overlay_root`: Root directory for overlay storage
  - `--boxsize`: Size of subvolumes to extract (z y x)
  - `--voxel_spacing`: Voxel spacing to use
  - `--include_background`: Include background samples
  - `--background_ratio`: Ratio of background to particle samples
  - `--min_background_distance`: Minimum distance from particles
  - `--verbose`: Enable verbose output

- Updated README with:
  - New section on saving and loading datasets
  - Command-line examples
  - Script options documentation

## Testing

The script has been tested with:
- Basic functionality checks
- Error handling for invalid parameters
- Various output directory configurations
- Different dataset configurations

This is a companion to the recently merged PR that added save/load capabilities to the MinimalCopickDataset class.