### PR TITLE
fix!: remove root-level imports for CLI speed.

### DIFF
--- a/copick_torch/__init__.py
+++ b/copick_torch/__init__.py
@@ -1,20 +1,20 @@
 __version__ = "0.2.1"
 
-from copick_torch.augmentations import FourierAugment3D, MixupTransform
-from copick_torch.copick import CopickDataset
-from copick_torch.dataset import SimpleCopickDataset, SimpleDatasetMixin, SplicedMixupDataset
-from copick_torch.logging import setup_logging
-from copick_torch.minimal_dataset import MinimalCopickDataset
-from copick_torch.samplers import ClassBalancedSampler
-
-__all__ = [
-    "CopickDataset",
-    "SimpleCopickDataset",
-    "SimpleDatasetMixin",
-    "SplicedMixupDataset",
-    "MinimalCopickDataset",
-    "MixupTransform",
-    "FourierAugment3D",
-    "ClassBalancedSampler",
-    "setup_logging",
-]
+# from copick_torch.augmentations import FourierAugment3D, MixupTransform
+# from copick_torch.copick import CopickDataset
+# from copick_torch.dataset import SimpleCopickDataset, SimpleDatasetMixin, SplicedMixupDataset
+# from copick_torch.logging import setup_logging
+# from copick_torch.minimal_dataset import MinimalCopickDataset
+# from copick_torch.samplers import ClassBalancedSampler
+#
+# __all__ = [
+#     "CopickDataset",
+#     "SimpleCopickDataset",
+#     "SimpleDatasetMixin",
+#     "SplicedMixupDataset",
+#     "MinimalCopickDataset",
+#     "MixupTransform",
+#     "FourierAugment3D",
+#     "ClassBalancedSampler",
+#     "setup_logging",
+# ]


### PR DESCRIPTION
(API-)Breaking change that remove pytorch-dependent imports at the module-root level. PyTorch-dependent code should be imported lazily to avoid massive slowdowns in CLI applications. 