### PR TITLE
feat: nnUNet integration for CoPick cryo-ET datasets

### DIFF
--- a/copick_torch/nnunet/__init__.py
+++ b/copick_torch/nnunet/__init__.py
@@ -12,9 +12,9 @@ def cli():
     pass
 
 
-from copick_torch.nnunet.prepare import cli as prepare_cli  # noqa: E402
-from copick_torch.nnunet.train import cli as train_cli      # noqa: E402
 from copick_torch.nnunet.predict import cli as predict_cli  # noqa: E402
+from copick_torch.nnunet.prepare import cli as prepare_cli  # noqa: E402
+from copick_torch.nnunet.train import cli as train_cli  # noqa: E402
 
 cli.add_command(prepare_cli, "prepare")
 cli.add_command(train_cli, "train")

--- a/copick_torch/nnunet/__init__.py
+++ b/copick_torch/nnunet/__init__.py
@@ -1,0 +1,21 @@
+import click
+
+_cli_context = {
+    "show_default": True,
+    "help_option_names": ["-h", "--help"],
+}
+
+
+@click.group("nnunet", context_settings=_cli_context, no_args_is_help=True)
+def cli():
+    """nnUNet integration for CoPick cryo-ET datasets."""
+    pass
+
+
+from copick_torch.nnunet.prepare import cli as prepare_cli  # noqa: E402
+from copick_torch.nnunet.train import cli as train_cli      # noqa: E402
+from copick_torch.nnunet.predict import cli as predict_cli  # noqa: E402
+
+cli.add_command(prepare_cli, "prepare")
+cli.add_command(train_cli, "train")
+cli.add_command(predict_cli, "segment")

--- a/copick_torch/nnunet/mednext_trainer.py
+++ b/copick_torch/nnunet/mednext_trainer.py
@@ -15,12 +15,21 @@ Variant specs (from create_mednext_v1.py):
   M — block_counts [3,4,4,4,4,4,4,4,3], exp_r [2,3,4,4,4,4,4,3,2], grad checkpointing
   L — block_counts [3,4,8,8,8,8,8,4,3], exp_r [3,4,8,8,8,8,8,4,3], grad checkpointing
 """
+
 from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
 
 
-def _build_mednext(num_input_channels, num_output_channels, enable_deep_supervision,
-                   kernel_size, block_counts, exp_r, checkpoint_style=None):
+def _build_mednext(
+    num_input_channels,
+    num_output_channels,
+    enable_deep_supervision,
+    kernel_size,
+    block_counts,
+    exp_r,
+    checkpoint_style=None,
+):
     from nnunet_mednext.network_architecture.mednextv1.MedNextV1 import MedNeXt
+
     return MedNeXt(
         in_channels=num_input_channels,
         n_channels=32,
@@ -49,13 +58,16 @@ class _MedNeXtTrainerBase(nnUNetTrainer):
 
 # ── Small (S) ────────────────────────────────────────────────────────────────
 
+
 class nnUNetTrainerMedNeXtS_kernel3(_MedNeXtTrainerBase):
     @staticmethod
-    def build_network_architecture(plans_manager, configuration_manager,
-                                   num_input_channels, num_output_channels,
-                                   enable_deep_supervision=True):
+    def build_network_architecture(
+        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+    ):
         return _build_mednext(
-            num_input_channels, num_output_channels, enable_deep_supervision,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
             kernel_size=3,
             block_counts=[2, 2, 2, 2, 2, 2, 2, 2, 2],
             exp_r=2,
@@ -64,11 +76,13 @@ class nnUNetTrainerMedNeXtS_kernel3(_MedNeXtTrainerBase):
 
 class nnUNetTrainerMedNeXtS_kernel5(_MedNeXtTrainerBase):
     @staticmethod
-    def build_network_architecture(plans_manager, configuration_manager,
-                                   num_input_channels, num_output_channels,
-                                   enable_deep_supervision=True):
+    def build_network_architecture(
+        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+    ):
         return _build_mednext(
-            num_input_channels, num_output_channels, enable_deep_supervision,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
             kernel_size=5,
             block_counts=[2, 2, 2, 2, 2, 2, 2, 2, 2],
             exp_r=2,
@@ -77,13 +91,16 @@ class nnUNetTrainerMedNeXtS_kernel5(_MedNeXtTrainerBase):
 
 # ── Base (B) ─────────────────────────────────────────────────────────────────
 
+
 class nnUNetTrainerMedNeXtB_kernel3(_MedNeXtTrainerBase):
     @staticmethod
-    def build_network_architecture(plans_manager, configuration_manager,
-                                   num_input_channels, num_output_channels,
-                                   enable_deep_supervision=True):
+    def build_network_architecture(
+        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+    ):
         return _build_mednext(
-            num_input_channels, num_output_channels, enable_deep_supervision,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
             kernel_size=3,
             block_counts=[2, 2, 2, 2, 2, 2, 2, 2, 2],
             exp_r=[2, 3, 4, 4, 4, 4, 4, 3, 2],
@@ -92,11 +109,13 @@ class nnUNetTrainerMedNeXtB_kernel3(_MedNeXtTrainerBase):
 
 class nnUNetTrainerMedNeXtB_kernel5(_MedNeXtTrainerBase):
     @staticmethod
-    def build_network_architecture(plans_manager, configuration_manager,
-                                   num_input_channels, num_output_channels,
-                                   enable_deep_supervision=True):
+    def build_network_architecture(
+        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+    ):
         return _build_mednext(
-            num_input_channels, num_output_channels, enable_deep_supervision,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
             kernel_size=5,
             block_counts=[2, 2, 2, 2, 2, 2, 2, 2, 2],
             exp_r=[2, 3, 4, 4, 4, 4, 4, 3, 2],
@@ -105,13 +124,16 @@ class nnUNetTrainerMedNeXtB_kernel5(_MedNeXtTrainerBase):
 
 # ── Medium (M) ───────────────────────────────────────────────────────────────
 
+
 class nnUNetTrainerMedNeXtM_kernel3(_MedNeXtTrainerBase):
     @staticmethod
-    def build_network_architecture(plans_manager, configuration_manager,
-                                   num_input_channels, num_output_channels,
-                                   enable_deep_supervision=True):
+    def build_network_architecture(
+        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+    ):
         return _build_mednext(
-            num_input_channels, num_output_channels, enable_deep_supervision,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
             kernel_size=3,
             block_counts=[3, 4, 4, 4, 4, 4, 4, 4, 3],
             exp_r=[2, 3, 4, 4, 4, 4, 4, 3, 2],
@@ -121,11 +143,13 @@ class nnUNetTrainerMedNeXtM_kernel3(_MedNeXtTrainerBase):
 
 class nnUNetTrainerMedNeXtM_kernel5(_MedNeXtTrainerBase):
     @staticmethod
-    def build_network_architecture(plans_manager, configuration_manager,
-                                   num_input_channels, num_output_channels,
-                                   enable_deep_supervision=True):
+    def build_network_architecture(
+        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+    ):
         return _build_mednext(
-            num_input_channels, num_output_channels, enable_deep_supervision,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
             kernel_size=5,
             block_counts=[3, 4, 4, 4, 4, 4, 4, 4, 3],
             exp_r=[2, 3, 4, 4, 4, 4, 4, 3, 2],
@@ -135,13 +159,16 @@ class nnUNetTrainerMedNeXtM_kernel5(_MedNeXtTrainerBase):
 
 # ── Large (L) ────────────────────────────────────────────────────────────────
 
+
 class nnUNetTrainerMedNeXtL_kernel3(_MedNeXtTrainerBase):
     @staticmethod
-    def build_network_architecture(plans_manager, configuration_manager,
-                                   num_input_channels, num_output_channels,
-                                   enable_deep_supervision=True):
+    def build_network_architecture(
+        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+    ):
         return _build_mednext(
-            num_input_channels, num_output_channels, enable_deep_supervision,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
             kernel_size=3,
             block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
             exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
@@ -151,11 +178,13 @@ class nnUNetTrainerMedNeXtL_kernel3(_MedNeXtTrainerBase):
 
 class nnUNetTrainerMedNeXtL_kernel5(_MedNeXtTrainerBase):
     @staticmethod
-    def build_network_architecture(plans_manager, configuration_manager,
-                                   num_input_channels, num_output_channels,
-                                   enable_deep_supervision=True):
+    def build_network_architecture(
+        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+    ):
         return _build_mednext(
-            num_input_channels, num_output_channels, enable_deep_supervision,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
             kernel_size=5,
             block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
             exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],

--- a/copick_torch/nnunet/mednext_trainer.py
+++ b/copick_torch/nnunet/mednext_trainer.py
@@ -59,10 +59,14 @@ class _MedNeXtTrainerBase(nnUNetTrainer):
 # ── Small (S) ────────────────────────────────────────────────────────────────
 
 
-class nnUNetTrainerMedNeXtS_kernel3(_MedNeXtTrainerBase):
+class nnUNetTrainerMedNeXtS_kernel3(_MedNeXtTrainerBase):  # noqa: N801
     @staticmethod
     def build_network_architecture(
-        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+        plans_manager,
+        configuration_manager,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=True,
     ):
         return _build_mednext(
             num_input_channels,
@@ -74,10 +78,14 @@ class nnUNetTrainerMedNeXtS_kernel3(_MedNeXtTrainerBase):
         )
 
 
-class nnUNetTrainerMedNeXtS_kernel5(_MedNeXtTrainerBase):
+class nnUNetTrainerMedNeXtS_kernel5(_MedNeXtTrainerBase):  # noqa: N801
     @staticmethod
     def build_network_architecture(
-        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+        plans_manager,
+        configuration_manager,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=True,
     ):
         return _build_mednext(
             num_input_channels,
@@ -92,10 +100,14 @@ class nnUNetTrainerMedNeXtS_kernel5(_MedNeXtTrainerBase):
 # ── Base (B) ─────────────────────────────────────────────────────────────────
 
 
-class nnUNetTrainerMedNeXtB_kernel3(_MedNeXtTrainerBase):
+class nnUNetTrainerMedNeXtB_kernel3(_MedNeXtTrainerBase):  # noqa: N801
     @staticmethod
     def build_network_architecture(
-        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+        plans_manager,
+        configuration_manager,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=True,
     ):
         return _build_mednext(
             num_input_channels,
@@ -107,10 +119,14 @@ class nnUNetTrainerMedNeXtB_kernel3(_MedNeXtTrainerBase):
         )
 
 
-class nnUNetTrainerMedNeXtB_kernel5(_MedNeXtTrainerBase):
+class nnUNetTrainerMedNeXtB_kernel5(_MedNeXtTrainerBase):  # noqa: N801
     @staticmethod
     def build_network_architecture(
-        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+        plans_manager,
+        configuration_manager,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=True,
     ):
         return _build_mednext(
             num_input_channels,
@@ -125,10 +141,14 @@ class nnUNetTrainerMedNeXtB_kernel5(_MedNeXtTrainerBase):
 # ── Medium (M) ───────────────────────────────────────────────────────────────
 
 
-class nnUNetTrainerMedNeXtM_kernel3(_MedNeXtTrainerBase):
+class nnUNetTrainerMedNeXtM_kernel3(_MedNeXtTrainerBase):  # noqa: N801
     @staticmethod
     def build_network_architecture(
-        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+        plans_manager,
+        configuration_manager,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=True,
     ):
         return _build_mednext(
             num_input_channels,
@@ -141,10 +161,14 @@ class nnUNetTrainerMedNeXtM_kernel3(_MedNeXtTrainerBase):
         )
 
 
-class nnUNetTrainerMedNeXtM_kernel5(_MedNeXtTrainerBase):
+class nnUNetTrainerMedNeXtM_kernel5(_MedNeXtTrainerBase):  # noqa: N801
     @staticmethod
     def build_network_architecture(
-        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+        plans_manager,
+        configuration_manager,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=True,
     ):
         return _build_mednext(
             num_input_channels,
@@ -160,10 +184,14 @@ class nnUNetTrainerMedNeXtM_kernel5(_MedNeXtTrainerBase):
 # ── Large (L) ────────────────────────────────────────────────────────────────
 
 
-class nnUNetTrainerMedNeXtL_kernel3(_MedNeXtTrainerBase):
+class nnUNetTrainerMedNeXtL_kernel3(_MedNeXtTrainerBase):  # noqa: N801
     @staticmethod
     def build_network_architecture(
-        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+        plans_manager,
+        configuration_manager,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=True,
     ):
         return _build_mednext(
             num_input_channels,
@@ -176,10 +204,14 @@ class nnUNetTrainerMedNeXtL_kernel3(_MedNeXtTrainerBase):
         )
 
 
-class nnUNetTrainerMedNeXtL_kernel5(_MedNeXtTrainerBase):
+class nnUNetTrainerMedNeXtL_kernel5(_MedNeXtTrainerBase):  # noqa: N801
     @staticmethod
     def build_network_architecture(
-        plans_manager, configuration_manager, num_input_channels, num_output_channels, enable_deep_supervision=True
+        plans_manager,
+        configuration_manager,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=True,
     ):
         return _build_mednext(
             num_input_channels,

--- a/copick_torch/nnunet/mednext_trainer.py
+++ b/copick_torch/nnunet/mednext_trainer.py
@@ -1,0 +1,163 @@
+"""
+nnUNet v2 compatible trainers for MedNeXt (mednextv1 package).
+
+Subclasses nnUNetTrainer and overrides build_network_architecture() to
+instantiate MedNeXt in place of nnUNet's default PlainConvUNet.
+
+This file is auto-copied into the nnunetv2 trainer directory by
+copick-torch nnunet train when a mednext model is selected.
+
+Requires: pip install git+https://github.com/MIC-DKFZ/MedNeXt.git
+
+Variant specs (from create_mednext_v1.py):
+  S — block_counts [2,2,2,2,2,2,2,2,2], exp_r 2 (scalar)
+  B — block_counts [2,2,2,2,2,2,2,2,2], exp_r [2,3,4,4,4,4,4,3,2]
+  M — block_counts [3,4,4,4,4,4,4,4,3], exp_r [2,3,4,4,4,4,4,3,2], grad checkpointing
+  L — block_counts [3,4,8,8,8,8,8,4,3], exp_r [3,4,8,8,8,8,8,4,3], grad checkpointing
+"""
+from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
+
+
+def _build_mednext(num_input_channels, num_output_channels, enable_deep_supervision,
+                   kernel_size, block_counts, exp_r, checkpoint_style=None):
+    from nnunet_mednext.network_architecture.mednextv1.MedNextV1 import MedNeXt
+    return MedNeXt(
+        in_channels=num_input_channels,
+        n_channels=32,
+        n_classes=num_output_channels,
+        exp_r=exp_r,
+        kernel_size=kernel_size,
+        deep_supervision=enable_deep_supervision,
+        do_res=True,
+        do_res_up_down=True,
+        block_counts=block_counts,
+        checkpoint_style=checkpoint_style,
+    )
+
+
+class _MedNeXtTrainerBase(nnUNetTrainer):
+    """Mixin that fixes deep_supervision toggling for MedNeXt models.
+
+    nnUNetTrainer.set_deep_supervision_enabled() assumes the network has a
+    .decoder sub-module, but MedNeXt exposes deep_supervision directly on the
+    top-level model object.
+    """
+
+    def set_deep_supervision_enabled(self, enabled: bool):
+        self.network.do_ds = enabled
+
+
+# ── Small (S) ────────────────────────────────────────────────────────────────
+
+class nnUNetTrainerMedNeXtS_kernel3(_MedNeXtTrainerBase):
+    @staticmethod
+    def build_network_architecture(plans_manager, configuration_manager,
+                                   num_input_channels, num_output_channels,
+                                   enable_deep_supervision=True):
+        return _build_mednext(
+            num_input_channels, num_output_channels, enable_deep_supervision,
+            kernel_size=3,
+            block_counts=[2, 2, 2, 2, 2, 2, 2, 2, 2],
+            exp_r=2,
+        )
+
+
+class nnUNetTrainerMedNeXtS_kernel5(_MedNeXtTrainerBase):
+    @staticmethod
+    def build_network_architecture(plans_manager, configuration_manager,
+                                   num_input_channels, num_output_channels,
+                                   enable_deep_supervision=True):
+        return _build_mednext(
+            num_input_channels, num_output_channels, enable_deep_supervision,
+            kernel_size=5,
+            block_counts=[2, 2, 2, 2, 2, 2, 2, 2, 2],
+            exp_r=2,
+        )
+
+
+# ── Base (B) ─────────────────────────────────────────────────────────────────
+
+class nnUNetTrainerMedNeXtB_kernel3(_MedNeXtTrainerBase):
+    @staticmethod
+    def build_network_architecture(plans_manager, configuration_manager,
+                                   num_input_channels, num_output_channels,
+                                   enable_deep_supervision=True):
+        return _build_mednext(
+            num_input_channels, num_output_channels, enable_deep_supervision,
+            kernel_size=3,
+            block_counts=[2, 2, 2, 2, 2, 2, 2, 2, 2],
+            exp_r=[2, 3, 4, 4, 4, 4, 4, 3, 2],
+        )
+
+
+class nnUNetTrainerMedNeXtB_kernel5(_MedNeXtTrainerBase):
+    @staticmethod
+    def build_network_architecture(plans_manager, configuration_manager,
+                                   num_input_channels, num_output_channels,
+                                   enable_deep_supervision=True):
+        return _build_mednext(
+            num_input_channels, num_output_channels, enable_deep_supervision,
+            kernel_size=5,
+            block_counts=[2, 2, 2, 2, 2, 2, 2, 2, 2],
+            exp_r=[2, 3, 4, 4, 4, 4, 4, 3, 2],
+        )
+
+
+# ── Medium (M) ───────────────────────────────────────────────────────────────
+
+class nnUNetTrainerMedNeXtM_kernel3(_MedNeXtTrainerBase):
+    @staticmethod
+    def build_network_architecture(plans_manager, configuration_manager,
+                                   num_input_channels, num_output_channels,
+                                   enable_deep_supervision=True):
+        return _build_mednext(
+            num_input_channels, num_output_channels, enable_deep_supervision,
+            kernel_size=3,
+            block_counts=[3, 4, 4, 4, 4, 4, 4, 4, 3],
+            exp_r=[2, 3, 4, 4, 4, 4, 4, 3, 2],
+            checkpoint_style="outside_block",
+        )
+
+
+class nnUNetTrainerMedNeXtM_kernel5(_MedNeXtTrainerBase):
+    @staticmethod
+    def build_network_architecture(plans_manager, configuration_manager,
+                                   num_input_channels, num_output_channels,
+                                   enable_deep_supervision=True):
+        return _build_mednext(
+            num_input_channels, num_output_channels, enable_deep_supervision,
+            kernel_size=5,
+            block_counts=[3, 4, 4, 4, 4, 4, 4, 4, 3],
+            exp_r=[2, 3, 4, 4, 4, 4, 4, 3, 2],
+            checkpoint_style="outside_block",
+        )
+
+
+# ── Large (L) ────────────────────────────────────────────────────────────────
+
+class nnUNetTrainerMedNeXtL_kernel3(_MedNeXtTrainerBase):
+    @staticmethod
+    def build_network_architecture(plans_manager, configuration_manager,
+                                   num_input_channels, num_output_channels,
+                                   enable_deep_supervision=True):
+        return _build_mednext(
+            num_input_channels, num_output_channels, enable_deep_supervision,
+            kernel_size=3,
+            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            checkpoint_style="outside_block",
+        )
+
+
+class nnUNetTrainerMedNeXtL_kernel5(_MedNeXtTrainerBase):
+    @staticmethod
+    def build_network_architecture(plans_manager, configuration_manager,
+                                   num_input_channels, num_output_channels,
+                                   enable_deep_supervision=True):
+        return _build_mednext(
+            num_input_channels, num_output_channels, enable_deep_supervision,
+            kernel_size=5,
+            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            checkpoint_style="outside_block",
+        )

--- a/copick_torch/nnunet/predict.py
+++ b/copick_torch/nnunet/predict.py
@@ -1,0 +1,511 @@
+"""
+nnUNet inference on CoPick tomograms.
+
+Usage
+-----
+Single tomogram:
+    from copick_torch.nnunet.predict import nnUNetPredictor
+    model = nnUNetPredictor(plans="plans.json", dataset_json="dataset.json", weights="checkpoint_best.pth")
+    seg   = model.predict(tomogram)          # np.ndarray (Z, Y, X) uint8
+
+Full CoPick project (auto multi-GPU):
+    model.batch_predict(copick_config="config.json", tomogram_uri="wbp@10.0", seg_uri="nnunet:nnunet/1")
+
+CLI:
+    copick-torch nnunet segment -c config.json -p plans.json -d dataset.json -w checkpoint.pth -uri wbp@10.0
+"""
+import os, warnings, pprint
+
+# nnunetv2 emits warnings when its path env-vars are unset; irrelevant for inference.
+warnings.filterwarnings("ignore", message="nnUNet_raw")
+warnings.filterwarnings("ignore", message="nnUNet_preprocessed")
+warnings.filterwarnings("ignore", message="nnUNet_results")
+
+os.environ.setdefault("NUMEXPR_MAX_THREADS", "16")
+
+import click
+
+# ── trainer class resolution ──────────────────────────────────────────────────
+
+def _resolve_trainer_class(trainer_name: str):
+    """
+    Return the trainer class for the given name.
+
+    For standard nnUNet trainers we do a direct import (fast).
+    For MedNeXt trainers we fall back to recursive_find_python_class, which
+    scans the trainer directory — slow but only needed once per session.
+    """
+    _DIRECT = {
+        "nnUNetTrainer":
+            "nnunetv2.training.nnUNetTrainer.nnUNetTrainer::nnUNetTrainer",
+        "nnUNetTrainerNoMirroring":
+            "nnunetv2.training.nnUNetTrainer.variants.training_length_and_nsteps.nnUNetTrainerNoMirroring::nnUNetTrainerNoMirroring",
+    }
+    if trainer_name in _DIRECT:
+        import importlib
+        module_path, class_name = _DIRECT[trainer_name].split("::")
+        mod = importlib.import_module(module_path)
+        return getattr(mod, class_name)
+
+    if "MedNeXt" in trainer_name:
+        from copick_torch.nnunet.utils import check_mednext_installed
+        check_mednext_installed()
+        try:
+            from nnunetv2.training.nnUNetTrainer.variants import nnUNetTrainerMedNeXt as _mn_mod
+            return getattr(_mn_mod, trainer_name)
+        except (ImportError, AttributeError):
+            pass
+
+    import nnunetv2
+    from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
+    cls = recursive_find_python_class(
+        os.path.join(nnunetv2.__path__[0], "training", "nnUNetTrainer"),
+        trainer_name,
+        "nnunetv2.training.nnUNetTrainer",
+    )
+    if cls is None:
+        raise RuntimeError(
+            f"Trainer class '{trainer_name}' not found. "
+            "For MedNeXt models, run `copick-torch nnunet train` once to register the trainer."
+        )
+    return cls
+
+
+# ── predictor ─────────────────────────────────────────────────────────────────
+
+class single_gpu_nnUNetPredictor:
+    """
+    nnUNet inference wrapper that accepts individual arrays rather than a folder.
+
+    Parameters
+    ----------
+    plans : str
+        Path to plans.json (written by nnUNetv2_plan_and_preprocess).
+    dataset_json : str
+        Path to dataset.json.
+    weights : str | list[str]
+        Path(s) to checkpoint .pth file(s).  Multiple paths are ensembled
+        by averaging logits before argmax.
+    tile_step_size : float
+        Sliding-window step as a fraction of patch size (lower = more overlap).
+    use_mirroring : bool
+        Enable nnUNet's built-in mirroring TTA.
+    device : torch.device | None
+        Inference device.  Defaults to cuda:0 if available.
+    """
+
+    def __init__(
+        self,
+        plans: str,
+        dataset_json: str,
+        weights: "str | list[str]",
+        tile_step_size: float = 0.5,
+        use_mirroring: bool = True,
+        device=None,
+    ):
+        from nnunetv2.utilities.label_handling.label_handling import determine_num_input_channels
+        from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor as _Pred
+        from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
+        import inspect, json, torch
+
+        if device is None:
+            device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
+
+        with open(plans) as f:
+            plans_dict = json.load(f)
+        with open(dataset_json) as f:
+            dataset_dict = json.load(f)
+
+        plans_manager = PlansManager(plans_dict)
+
+        if isinstance(weights, str):
+            weights = [weights]
+
+        parameters = []
+        trainer_name = configuration_name = mirroring_axes = None
+
+        for i, w in enumerate(weights):
+            ckpt = torch.load(w, map_location="cpu", weights_only=False)
+            if i == 0:
+                trainer_name       = ckpt["trainer_name"]
+                configuration_name = ckpt["init_args"]["configuration"]
+                mirroring_axes     = ckpt.get("inference_allowed_mirroring_axes")
+            parameters.append(ckpt["network_weights"])
+
+        configuration_manager = plans_manager.get_configuration(configuration_name)
+
+        trainer_class = _resolve_trainer_class(trainer_name)
+
+        num_input_channels  = determine_num_input_channels(plans_manager, configuration_manager, dataset_dict)
+        num_output_channels = plans_manager.get_label_manager(dataset_dict).num_segmentation_heads
+
+        # Build with deep_supervision=True so the architecture matches the checkpoint.
+        # (MedNeXt omits output-head layers when ds is False, causing load_state_dict to fail.)
+        sig = inspect.signature(trainer_class.build_network_architecture)
+        if "plans_manager" in sig.parameters:
+            network = trainer_class.build_network_architecture(
+                plans_manager, configuration_manager,
+                num_input_channels, num_output_channels,
+                enable_deep_supervision=True,
+            )
+        else:
+            network = trainer_class.build_network_architecture(
+                configuration_manager.network_arch_class_name,
+                configuration_manager.network_arch_init_kwargs,
+                configuration_manager.network_arch_init_kwargs_req_import,
+                num_input_channels, num_output_channels,
+                enable_deep_supervision=True,
+            )
+
+        # Disable deep supervision for inference.
+        if hasattr(network, "decoder") and hasattr(network.decoder, "deep_supervision"):
+            network.decoder.deep_supervision = False
+        elif hasattr(network, "do_ds"):
+            network.do_ds = False
+
+        self._predictor = _Pred(
+            tile_step_size=tile_step_size,
+            use_gaussian=True,
+            use_mirroring=use_mirroring,
+            perform_everything_on_device=True,
+            device=device,
+            verbose=False,
+        )
+        self._predictor.manual_initialization(
+            network=network,
+            plans_manager=plans_manager,
+            configuration_manager=configuration_manager,
+            parameters=parameters,
+            dataset_json=dataset_dict,
+            trainer_name=trainer_name,
+            inference_allowed_mirroring_axes=mirroring_axes,
+        )
+
+        print(f"Loaded nnUNet model  trainer={trainer_name}  config={configuration_name}  folds={len(weights)}  device={device}")
+
+    def predict(self, tomogram: "np.ndarray", voxel_size_angstrom: float = 10.0) -> "np.ndarray":
+        """
+        Predict segmentation for a single tomogram.
+
+        Parameters
+        ----------
+        tomogram : np.ndarray, shape (Z, Y, X)
+        voxel_size_angstrom : float
+            Voxel spacing in Angstrom — converted to nm (÷10) for nnUNet.
+
+        Returns
+        -------
+        np.ndarray, shape (Z, Y, X), dtype uint8
+        """
+        import numpy as np
+
+        if tomogram.ndim == 3:
+            tomogram = tomogram[np.newaxis]
+        tomogram = tomogram.astype(np.float32)
+
+        spacing_nm = float(voxel_size_angstrom) / 10.0
+        props = {"spacing": [spacing_nm, spacing_nm, spacing_nm]}
+
+        seg = self._predictor.predict_single_npy_array(
+            tomogram, props,
+            segmentation_previous_stage=None,
+            output_file_truncated=None,
+            save_or_return_probabilities=False,
+        )
+        return seg.astype(np.uint8)
+
+    def batch_predict(
+        self,
+        copick_config: str,
+        tomogram_uri: str,
+        seg_uri: str = "predict:nnunet/1",
+        run_ids=None,
+    ):
+        """
+        Run inference on CoPick runs and write predictions back as segmentations.
+
+        Parameters
+        ----------
+        tomogram_uri : str
+            URI in ``algorithm@voxel_size`` format, e.g. ``"wbp@10.0"``.
+        seg_uri : str
+            Output segmentation URI in ``name:user_id/session_id`` format.
+        run_ids : list[str] | None
+            Specific run names to process.  None = all runs in the project.
+        """
+        import copick
+        from copick_utils.io import writers
+        from copick.util.uri import resolve_copick_objects
+        from tqdm import tqdm
+
+        try:
+            _, voxel_size_str = tomogram_uri.split("@")
+            voxel_size = float(voxel_size_str)
+        except ValueError:
+            raise ValueError(f"tomogram_uri must be 'algorithm@voxel_size', got: {tomogram_uri!r}")
+
+        try:
+            seg_name, rest = seg_uri.split(":")
+            user_id, session_id = rest.split("/")
+        except ValueError:
+            raise ValueError(f"seg_uri must be 'name:user_id/session_id', got: {seg_uri!r}")
+
+        root = copick.from_file(copick_config)
+        runs = root.runs if run_ids is None else [root.get_run(r) for r in run_ids]
+
+        for run in tqdm(runs, desc="Running nnUNet inference"):
+            if run is None:
+                continue
+            vols = resolve_copick_objects(tomogram_uri, root, "tomogram", run_name=run.name)
+            if not vols:
+                print(f"  [SKIP] No tomogram found for run '{run.name}'")
+                continue
+
+            seg = self.predict(vols[0].numpy(), voxel_size_angstrom=voxel_size)
+            writers.segmentation(
+                run, seg,
+                voxel_size=voxel_size,
+                name=seg_name,
+                user_id=user_id,
+                session_id=session_id,
+            )
+
+        print("Done writing predictions to CoPick.")
+
+
+# ── multi-GPU inference ────────────────────────────────────────────────────────
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _NnUNetJobSpec:
+    plans: str
+    dataset_json: str
+    weights: list
+    tile_step_size: float
+    use_mirroring: bool
+    copick_config: str
+    tomogram_uri: str
+    seg_uri: str
+    run_ids: list = field(default_factory=list)
+
+
+def _nnunet_worker(rank: int, jobs: list):
+    """One process per GPU — loads the model on cuda:{rank} and processes its shard."""
+    import torch
+    torch.cuda.set_device(rank)
+    torch.set_num_threads(max(1, (os.cpu_count() or 1) // max(1, torch.cuda.device_count())))
+
+    job = jobs[rank]
+    predictor = single_gpu_nnUNetPredictor(
+        plans=job.plans,
+        dataset_json=job.dataset_json,
+        weights=job.weights,
+        tile_step_size=job.tile_step_size,
+        use_mirroring=job.use_mirroring,
+        device=torch.device(f"cuda:{rank}"),
+    )
+    if job.run_ids:
+        predictor.batch_predict(
+            copick_config=job.copick_config,
+            tomogram_uri=job.tomogram_uri,
+            seg_uri=job.seg_uri,
+            run_ids=job.run_ids,
+        )
+
+
+class nnUNetPredictor:
+    """
+    Universal nnUNet predictor — automatically uses all available GPUs for batch_predict.
+
+    For single-tomogram inference (predict) the model is loaded on-demand on cuda:0.
+    For batch inference (batch_predict) run IDs are sharded round-robin across all GPUs
+    using mp.spawn (one process per GPU, CUDA-safe).
+
+    Usage
+    -----
+    predictor = nnUNetPredictor(plans=..., dataset_json=..., weights=...)
+    seg = predictor.predict(tomogram)                            # single volume, single GPU
+    predictor.batch_predict(copick_config=..., tomogram_uri=..., seg_uri=...)  # all GPUs
+    """
+
+    def __init__(
+        self,
+        plans: str,
+        dataset_json: str,
+        weights: "str | list[str]",
+        tile_step_size: float = 0.5,
+        use_mirroring: bool = True,
+    ):
+        self.plans          = plans
+        self.dataset_json   = dataset_json
+        self.weights        = [weights] if isinstance(weights, str) else weights
+        self.tile_step_size = tile_step_size
+        self.use_mirroring  = use_mirroring
+        self._single        = None  # lazy-loaded on first predict() call
+
+    def _get_single_predictor(self):
+        if self._single is None:
+            self._single = single_gpu_nnUNetPredictor(
+                plans=self.plans,
+                dataset_json=self.dataset_json,
+                weights=self.weights,
+                tile_step_size=self.tile_step_size,
+                use_mirroring=self.use_mirroring,
+            )
+        return self._single
+
+    def predict(self, tomogram: "np.ndarray", voxel_size_angstrom: float = 10.0) -> "np.ndarray":
+        """Predict segmentation for a single tomogram on cuda:0."""
+        return self._get_single_predictor().predict(tomogram, voxel_size_angstrom)
+
+    def save_parameters(self, copick_config: str, tomogram_uri: str, seg_uri: str):
+        from copick_torch.nnunet.utils import remove_prefix, save_parameters_yaml
+        import copick, json
+
+        seg_name, rest = seg_uri.split(":")
+        user_id, session_id = rest.split("/")
+
+        with open(self.dataset_json) as f:
+            dataset_dict = json.load(f)
+
+        params = {
+            "inputs": {
+                "config": copick_config,
+                "tomo_uri": tomogram_uri,
+            },
+            "labels": dataset_dict.get("labels", {}),
+            "model": {
+                "plans": self.plans,
+                "dataset_json": self.dataset_json,
+                "weights": self.weights,
+            },
+            "outputs": {
+                "obj_name": seg_name,
+                "user_id": user_id,
+                "session_id": session_id,
+            },
+            "parameters": {
+                "tile_step_size": self.tile_step_size,
+                "use_mirroring": self.use_mirroring,
+            },
+        }
+
+        print("\nParameters for Inference (nnUNet Prediction):")
+        pprint.pprint(params); print()
+
+        root = copick.from_file(copick_config)
+        overlay_root = remove_prefix(root.config.overlay_root)
+        basepath = os.path.join(overlay_root, "logs")
+        os.makedirs(basepath, exist_ok=True)
+        output_path = os.path.join(
+            basepath,
+            f"nnunet-{user_id}_{session_id}_{seg_name}.yaml",
+        )
+        save_parameters_yaml(params, output_path)
+
+    def batch_predict(
+        self,
+        copick_config: str,
+        tomogram_uri: str,
+        seg_uri: str,
+        run_ids=None,
+    ):
+        """
+        Run inference on CoPick runs across all available GPUs.
+
+        Parameters
+        ----------
+        tomogram_uri : str
+            URI in ``algorithm@voxel_size`` format, e.g. ``"wbp@10.0"``.
+        seg_uri : str
+            Output segmentation URI in ``name:user_id/session_id`` format.
+        run_ids : list[str] | None
+            Specific run names to process.  None = all runs in the project.
+        """
+        import torch.multiprocessing as mp
+        import torch, copick
+
+        self.save_parameters(copick_config, tomogram_uri, seg_uri)
+
+        world_size = torch.cuda.device_count()
+        if world_size < 1:
+            raise RuntimeError("No CUDA GPUs available.")
+
+        if run_ids is None:
+            root    = copick.from_file(copick_config)
+            run_ids = [r.name for r in root.runs]
+
+        if world_size == 1:
+            self._get_single_predictor().batch_predict(
+                copick_config=copick_config,
+                tomogram_uri=tomogram_uri,
+                seg_uri=seg_uri,
+                run_ids=run_ids,
+            )
+            return
+
+        shards = [[] for _ in range(world_size)]
+        for i, rid in enumerate(run_ids):
+            shards[i % world_size].append(rid)
+
+        jobs = [
+            _NnUNetJobSpec(
+                plans=self.plans,
+                dataset_json=self.dataset_json,
+                weights=self.weights,
+                tile_step_size=self.tile_step_size,
+                use_mirroring=self.use_mirroring,
+                copick_config=copick_config,
+                tomogram_uri=tomogram_uri,
+                seg_uri=seg_uri,
+                run_ids=shard,
+            )
+            for shard in shards
+        ]
+
+        mp.spawn(_nnunet_worker, args=(jobs,), nprocs=world_size, join=True)
+        print("Done writing predictions to CoPick.")
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+@click.command("nnunet", no_args_is_help=True)
+@click.option("-c", "--config", required=True, type=click.Path(exists=True),
+              help="Path to copick config.json")
+@click.option("-p", "--plans", required=True, type=click.Path(exists=True),
+              help="Path to nnunet plans.json")
+@click.option("-d", "--dataset", required=True, type=click.Path(exists=True),
+              help="Path to nnunet dataset.json")
+@click.option("-w", "--weights", required=True, type=click.Path(exists=True), multiple=True,
+              help="Path to checkpoint .pth (repeat for fold ensembling, "
+                   "e.g. -w fold_0/checkpoint_best.pth -w fold_1/checkpoint_best.pth)")
+@click.option("-turi", "--tomo-uri", type=str, default="wbp@10.0",
+              help="Tomogram URI to predict")
+@click.option("--tta", type=bool, default=True,
+              help="Enable mirroring TTA.")
+@click.option("--run-ids", "-runs", type=str, default=None,
+              help="CoPick run IDs to predict (comma-separated).")
+@click.option("-suri", "--seg-uri", type=str, default="predict:nnunet/1",
+              help="Segmentation URI to write (name:user_id/session_id)")
+def cli(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri):
+    """Run nnUNet inference on CoPick tomograms and write predictions back."""
+    run_predict(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri)
+
+
+def run_predict(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri):
+    run_ids_list = run_ids.split(",") if run_ids else None
+
+    predictor = nnUNetPredictor(
+        plans=plans,
+        dataset_json=dataset,
+        weights=weights,
+        use_mirroring=tta,
+    )
+    predictor.batch_predict(
+        copick_config=config,
+        tomogram_uri=tomo_uri,
+        seg_uri=seg_uri,
+        run_ids=run_ids_list,
+    )

--- a/copick_torch/nnunet/predict.py
+++ b/copick_torch/nnunet/predict.py
@@ -16,8 +16,12 @@ CLI:
 """
 
 import os
-import pprint
 import warnings
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
 
 # nnunetv2 emits warnings when its path env-vars are unset; irrelevant for inference.
 warnings.filterwarnings("ignore", message="nnUNet_raw")
@@ -26,7 +30,7 @@ warnings.filterwarnings("ignore", message="nnUNet_results")
 
 os.environ.setdefault("NUMEXPR_MAX_THREADS", "16")
 
-import click
+import click  # noqa: E402
 
 # ── trainer class resolution ──────────────────────────────────────────────────
 
@@ -55,7 +59,7 @@ def _resolve_trainer_class(trainer_name: str):
 
         check_mednext_installed()
         try:
-            from nnunetv2.training.nnUNetTrainer.variants import nnUNetTrainerMedNeXt as _mn_mod
+            from nnunetv2.training.nnUNetTrainer.variants import nnUNetTrainerMedNeXt as _mn_mod  # noqa: N813
 
             return getattr(_mn_mod, trainer_name)
         except (ImportError, AttributeError):
@@ -80,7 +84,7 @@ def _resolve_trainer_class(trainer_name: str):
 # ── predictor ─────────────────────────────────────────────────────────────────
 
 
-class single_gpu_nnUNetPredictor:
+class single_gpu_nnUNetPredictor:  # noqa: N801
     """
     nnUNet inference wrapper that accepts individual arrays rather than a folder.
 
@@ -195,7 +199,7 @@ class single_gpu_nnUNetPredictor:
         )
 
         print(
-            f"Loaded nnUNet model  trainer={trainer_name}  config={configuration_name}  folds={len(weights)}  device={device}"
+            f"Loaded nnUNet model  trainer={trainer_name}  config={configuration_name}  folds={len(weights)}  device={device}",
         )
 
     def predict(self, tomogram: "np.ndarray", voxel_size_angstrom: float = 10.0) -> "np.ndarray":
@@ -258,13 +262,13 @@ class single_gpu_nnUNetPredictor:
             _, voxel_size_str = tomogram_uri.split("@")
             voxel_size = float(voxel_size_str)
         except ValueError:
-            raise ValueError(f"tomogram_uri must be 'algorithm@voxel_size', got: {tomogram_uri!r}")
+            raise ValueError(f"tomogram_uri must be 'algorithm@voxel_size', got: {tomogram_uri!r}") from None
 
         try:
             seg_name, rest = seg_uri.split(":")
             user_id, session_id = rest.split("/")
         except ValueError:
-            raise ValueError(f"seg_uri must be 'name:user_id/session_id', got: {seg_uri!r}")
+            raise ValueError(f"seg_uri must be 'name:user_id/session_id', got: {seg_uri!r}") from None
 
         root = copick.from_file(copick_config)
         runs = root.runs if run_ids is None else [root.get_run(r) for r in run_ids]
@@ -291,8 +295,6 @@ class single_gpu_nnUNetPredictor:
 
 
 # ── multi-GPU inference ────────────────────────────────────────────────────────
-
-from dataclasses import dataclass, field
 
 
 @dataclass
@@ -333,7 +335,7 @@ def _nnunet_worker(rank: int, jobs: list):
         )
 
 
-class nnUNetPredictor:
+class nnUNetPredictor:  # noqa: N801
     """
     Universal nnUNet predictor — automatically uses all available GPUs for batch_predict.
 
@@ -414,7 +416,7 @@ class nnUNetPredictor:
         }
 
         print("\nParameters for Inference (nnUNet Prediction):")
-        pprint.pprint(params)
+        print(json.dumps(params, indent=2))
         print()
 
         root = copick.from_file(copick_config)

--- a/copick_torch/nnunet/predict.py
+++ b/copick_torch/nnunet/predict.py
@@ -14,7 +14,10 @@ Full CoPick project (auto multi-GPU):
 CLI:
     copick-torch nnunet segment -c config.json -p plans.json -d dataset.json -w checkpoint.pth -uri wbp@10.0
 """
-import os, warnings, pprint
+
+import os
+import pprint
+import warnings
 
 # nnunetv2 emits warnings when its path env-vars are unset; irrelevant for inference.
 warnings.filterwarnings("ignore", message="nnUNet_raw")
@@ -27,6 +30,7 @@ import click
 
 # ── trainer class resolution ──────────────────────────────────────────────────
 
+
 def _resolve_trainer_class(trainer_name: str):
     """
     Return the trainer class for the given name.
@@ -36,28 +40,30 @@ def _resolve_trainer_class(trainer_name: str):
     scans the trainer directory — slow but only needed once per session.
     """
     _DIRECT = {
-        "nnUNetTrainer":
-            "nnunetv2.training.nnUNetTrainer.nnUNetTrainer::nnUNetTrainer",
-        "nnUNetTrainerNoMirroring":
-            "nnunetv2.training.nnUNetTrainer.variants.training_length_and_nsteps.nnUNetTrainerNoMirroring::nnUNetTrainerNoMirroring",
+        "nnUNetTrainer": "nnunetv2.training.nnUNetTrainer.nnUNetTrainer::nnUNetTrainer",
+        "nnUNetTrainerNoMirroring": "nnunetv2.training.nnUNetTrainer.variants.training_length_and_nsteps.nnUNetTrainerNoMirroring::nnUNetTrainerNoMirroring",
     }
     if trainer_name in _DIRECT:
         import importlib
+
         module_path, class_name = _DIRECT[trainer_name].split("::")
         mod = importlib.import_module(module_path)
         return getattr(mod, class_name)
 
     if "MedNeXt" in trainer_name:
         from copick_torch.nnunet.utils import check_mednext_installed
+
         check_mednext_installed()
         try:
             from nnunetv2.training.nnUNetTrainer.variants import nnUNetTrainerMedNeXt as _mn_mod
+
             return getattr(_mn_mod, trainer_name)
         except (ImportError, AttributeError):
             pass
 
     import nnunetv2
     from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
+
     cls = recursive_find_python_class(
         os.path.join(nnunetv2.__path__[0], "training", "nnUNetTrainer"),
         trainer_name,
@@ -66,12 +72,13 @@ def _resolve_trainer_class(trainer_name: str):
     if cls is None:
         raise RuntimeError(
             f"Trainer class '{trainer_name}' not found. "
-            "For MedNeXt models, run `copick-torch nnunet train` once to register the trainer."
+            "For MedNeXt models, run `copick-torch nnunet train` once to register the trainer.",
         )
     return cls
 
 
 # ── predictor ─────────────────────────────────────────────────────────────────
+
 
 class single_gpu_nnUNetPredictor:
     """
@@ -103,10 +110,13 @@ class single_gpu_nnUNetPredictor:
         use_mirroring: bool = True,
         device=None,
     ):
-        from nnunetv2.utilities.label_handling.label_handling import determine_num_input_channels
+        import inspect
+        import json
+
+        import torch
         from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor as _Pred
+        from nnunetv2.utilities.label_handling.label_handling import determine_num_input_channels
         from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
-        import inspect, json, torch
 
         if device is None:
             device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
@@ -127,16 +137,16 @@ class single_gpu_nnUNetPredictor:
         for i, w in enumerate(weights):
             ckpt = torch.load(w, map_location="cpu", weights_only=False)
             if i == 0:
-                trainer_name       = ckpt["trainer_name"]
+                trainer_name = ckpt["trainer_name"]
                 configuration_name = ckpt["init_args"]["configuration"]
-                mirroring_axes     = ckpt.get("inference_allowed_mirroring_axes")
+                mirroring_axes = ckpt.get("inference_allowed_mirroring_axes")
             parameters.append(ckpt["network_weights"])
 
         configuration_manager = plans_manager.get_configuration(configuration_name)
 
         trainer_class = _resolve_trainer_class(trainer_name)
 
-        num_input_channels  = determine_num_input_channels(plans_manager, configuration_manager, dataset_dict)
+        num_input_channels = determine_num_input_channels(plans_manager, configuration_manager, dataset_dict)
         num_output_channels = plans_manager.get_label_manager(dataset_dict).num_segmentation_heads
 
         # Build with deep_supervision=True so the architecture matches the checkpoint.
@@ -144,8 +154,10 @@ class single_gpu_nnUNetPredictor:
         sig = inspect.signature(trainer_class.build_network_architecture)
         if "plans_manager" in sig.parameters:
             network = trainer_class.build_network_architecture(
-                plans_manager, configuration_manager,
-                num_input_channels, num_output_channels,
+                plans_manager,
+                configuration_manager,
+                num_input_channels,
+                num_output_channels,
                 enable_deep_supervision=True,
             )
         else:
@@ -153,7 +165,8 @@ class single_gpu_nnUNetPredictor:
                 configuration_manager.network_arch_class_name,
                 configuration_manager.network_arch_init_kwargs,
                 configuration_manager.network_arch_init_kwargs_req_import,
-                num_input_channels, num_output_channels,
+                num_input_channels,
+                num_output_channels,
                 enable_deep_supervision=True,
             )
 
@@ -181,7 +194,9 @@ class single_gpu_nnUNetPredictor:
             inference_allowed_mirroring_axes=mirroring_axes,
         )
 
-        print(f"Loaded nnUNet model  trainer={trainer_name}  config={configuration_name}  folds={len(weights)}  device={device}")
+        print(
+            f"Loaded nnUNet model  trainer={trainer_name}  config={configuration_name}  folds={len(weights)}  device={device}"
+        )
 
     def predict(self, tomogram: "np.ndarray", voxel_size_angstrom: float = 10.0) -> "np.ndarray":
         """
@@ -207,7 +222,8 @@ class single_gpu_nnUNetPredictor:
         props = {"spacing": [spacing_nm, spacing_nm, spacing_nm]}
 
         seg = self._predictor.predict_single_npy_array(
-            tomogram, props,
+            tomogram,
+            props,
             segmentation_previous_stage=None,
             output_file_truncated=None,
             save_or_return_probabilities=False,
@@ -234,8 +250,8 @@ class single_gpu_nnUNetPredictor:
             Specific run names to process.  None = all runs in the project.
         """
         import copick
-        from copick_utils.io import writers
         from copick.util.uri import resolve_copick_objects
+        from copick_utils.io import writers
         from tqdm import tqdm
 
         try:
@@ -263,7 +279,8 @@ class single_gpu_nnUNetPredictor:
 
             seg = self.predict(vols[0].numpy(), voxel_size_angstrom=voxel_size)
             writers.segmentation(
-                run, seg,
+                run,
+                seg,
                 voxel_size=voxel_size,
                 name=seg_name,
                 user_id=user_id,
@@ -294,6 +311,7 @@ class _NnUNetJobSpec:
 def _nnunet_worker(rank: int, jobs: list):
     """One process per GPU — loads the model on cuda:{rank} and processes its shard."""
     import torch
+
     torch.cuda.set_device(rank)
     torch.set_num_threads(max(1, (os.cpu_count() or 1) // max(1, torch.cuda.device_count())))
 
@@ -338,12 +356,12 @@ class nnUNetPredictor:
         tile_step_size: float = 0.5,
         use_mirroring: bool = True,
     ):
-        self.plans          = plans
-        self.dataset_json   = dataset_json
-        self.weights        = [weights] if isinstance(weights, str) else weights
+        self.plans = plans
+        self.dataset_json = dataset_json
+        self.weights = [weights] if isinstance(weights, str) else weights
         self.tile_step_size = tile_step_size
-        self.use_mirroring  = use_mirroring
-        self._single        = None  # lazy-loaded on first predict() call
+        self.use_mirroring = use_mirroring
+        self._single = None  # lazy-loaded on first predict() call
 
     def _get_single_predictor(self):
         if self._single is None:
@@ -361,8 +379,11 @@ class nnUNetPredictor:
         return self._get_single_predictor().predict(tomogram, voxel_size_angstrom)
 
     def save_parameters(self, copick_config: str, tomogram_uri: str, seg_uri: str):
+        import json
+
+        import copick
+
         from copick_torch.nnunet.utils import remove_prefix, save_parameters_yaml
-        import copick, json
 
         seg_name, rest = seg_uri.split(":")
         user_id, session_id = rest.split("/")
@@ -393,7 +414,8 @@ class nnUNetPredictor:
         }
 
         print("\nParameters for Inference (nnUNet Prediction):")
-        pprint.pprint(params); print()
+        pprint.pprint(params)
+        print()
 
         root = copick.from_file(copick_config)
         overlay_root = remove_prefix(root.config.overlay_root)
@@ -424,8 +446,9 @@ class nnUNetPredictor:
         run_ids : list[str] | None
             Specific run names to process.  None = all runs in the project.
         """
+        import copick
+        import torch
         import torch.multiprocessing as mp
-        import torch, copick
 
         self.save_parameters(copick_config, tomogram_uri, seg_uri)
 
@@ -434,7 +457,7 @@ class nnUNetPredictor:
             raise RuntimeError("No CUDA GPUs available.")
 
         if run_ids is None:
-            root    = copick.from_file(copick_config)
+            root = copick.from_file(copick_config)
             run_ids = [r.name for r in root.runs]
 
         if world_size == 1:
@@ -471,24 +494,30 @@ class nnUNetPredictor:
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
 
+
 @click.command("nnunet", no_args_is_help=True)
-@click.option("-c", "--config", required=True, type=click.Path(exists=True),
-              help="Path to copick config.json")
-@click.option("-p", "--plans", required=True, type=click.Path(exists=True),
-              help="Path to nnunet plans.json")
-@click.option("-d", "--dataset", required=True, type=click.Path(exists=True),
-              help="Path to nnunet dataset.json")
-@click.option("-w", "--weights", required=True, type=click.Path(exists=True), multiple=True,
-              help="Path to checkpoint .pth (repeat for fold ensembling, "
-                   "e.g. -w fold_0/checkpoint_best.pth -w fold_1/checkpoint_best.pth)")
-@click.option("-turi", "--tomo-uri", type=str, default="wbp@10.0",
-              help="Tomogram URI to predict")
-@click.option("--tta", type=bool, default=True,
-              help="Enable mirroring TTA.")
-@click.option("--run-ids", "-runs", type=str, default=None,
-              help="CoPick run IDs to predict (comma-separated).")
-@click.option("-suri", "--seg-uri", type=str, default="predict:nnunet/1",
-              help="Segmentation URI to write (name:user_id/session_id)")
+@click.option("-c", "--config", required=True, type=click.Path(exists=True), help="Path to copick config.json")
+@click.option("-p", "--plans", required=True, type=click.Path(exists=True), help="Path to nnunet plans.json")
+@click.option("-d", "--dataset", required=True, type=click.Path(exists=True), help="Path to nnunet dataset.json")
+@click.option(
+    "-w",
+    "--weights",
+    required=True,
+    type=click.Path(exists=True),
+    multiple=True,
+    help="Path to checkpoint .pth (repeat for fold ensembling, "
+    "e.g. -w fold_0/checkpoint_best.pth -w fold_1/checkpoint_best.pth)",
+)
+@click.option("-turi", "--tomo-uri", type=str, default="wbp@10.0", help="Tomogram URI to predict")
+@click.option("--tta", type=bool, default=True, help="Enable mirroring TTA.")
+@click.option("--run-ids", "-runs", type=str, default=None, help="CoPick run IDs to predict (comma-separated).")
+@click.option(
+    "-suri",
+    "--seg-uri",
+    type=str,
+    default="predict:nnunet/1",
+    help="Segmentation URI to write (name:user_id/session_id)",
+)
 def cli(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri):
     """Run nnUNet inference on CoPick tomograms and write predictions back."""
     run_predict(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri)

--- a/copick_torch/nnunet/prepare.py
+++ b/copick_torch/nnunet/prepare.py
@@ -224,7 +224,7 @@ def convert(cfg: dict):
         print(f"  Skipped runs   : {skipped}")
 
 
-@click.command("nnunet", no_args_is_help=True)
+@click.command("nnunet", no_args_is_help=True, context_settings={"show_default": True})
 @click.option("-c", "--config", required=True, type=click.Path(exists=True), help="Path to copick config.json")
 @click.option("-uri", "--tomo-uri", type=str, default="wbp@10.0", help="Tomogram URI to use for training")
 @click.option(
@@ -236,7 +236,7 @@ def convert(cfg: dict):
     help="Segmentation info as 'name' or 'name,user_id,session_id'",
 )
 @click.option(
-    "-truns",
+    "-train",
     "--train-run-ids",
     type=str,
     default=None,
@@ -244,7 +244,7 @@ def convert(cfg: dict):
     help="Training run IDs, e.g. run1,run2,run3. Default: all runs not in test set.",
 )
 @click.option(
-    "-tests",
+    "-test",
     "--test-run-ids",
     type=str,
     default=None,
@@ -252,18 +252,17 @@ def convert(cfg: dict):
     help="Test run IDs, e.g. run4,run5",
 )
 @click.option(
-    "-did",
+    "-id",
     "--dataset-id",
     type=int,
     required=False,
     default=1,
     help="nnUNet dataset ID (integer; becomes Dataset{id}_{name})",
 )
-@click.option("-dname", "--dataset-name", type=str, required=True, help="nnUNet dataset name")
+@click.option("-n", "--dataset-name", type=str, required=True, help="nnUNet dataset name")
 @click.option(
-    "-raw",
-    "--raw",
-    "nnunet_raw",
+    "-o",
+    "--output",
     type=click.Path(),
     required=True,
     help="Path to nnunet_raw output directory",
@@ -276,7 +275,7 @@ def convert(cfg: dict):
     type=int,
     help="Number of parallel worker threads for converting tomograms.",
 )
-def cli(config, tomo_uri, seg_info, train_run_ids, test_run_ids, dataset_id, dataset_name, nnunet_raw, num_workers):
+def cli(config, tomo_uri, seg_info, train_run_ids, test_run_ids, dataset_id, dataset_name, output, num_workers):
     """Convert a CoPick project to nnUNet raw dataset format (imagesTr / labelsTr / imagesTs)."""
     cfg = {
         "copick_config": config,
@@ -284,7 +283,7 @@ def cli(config, tomo_uri, seg_info, train_run_ids, test_run_ids, dataset_id, dat
         "seg_info": seg_info,
         "dataset_id": dataset_id,
         "dataset_name": dataset_name,
-        "nnunet_raw": nnunet_raw,
+        "nnunet_raw": output,
         "train_run_ids": train_run_ids or [],
         "test_run_ids": test_run_ids or [],
         "num_workers": num_workers,

--- a/copick_torch/nnunet/prepare.py
+++ b/copick_torch/nnunet/prepare.py
@@ -1,0 +1,264 @@
+"""
+Convert a CoPick project to nnUNet raw dataset format.
+
+Reads tomograms and segmentation masks from CoPick and writes them as
+.nii.gz files in the nnUNet Dataset folder structure:
+
+    nnunet_raw/
+    └── Dataset{id}_{name}/
+        ├── dataset.json
+        ├── imagesTr/   {case}_0000.nii.gz
+        ├── labelsTr/   {case}.nii.gz
+        └── imagesTs/   {case}_0000.nii.gz   (if test_run_ids provided)
+"""
+import click
+import numpy as np
+
+
+def _parse_list(value: str) -> list[str]:
+    return [x.strip() for x in value.strip("[]").split(",")]
+
+
+def _parse_target(value: str) -> tuple:
+    parts = value.split(",")
+    if len(parts) == 1:
+        return parts[0], None, None
+    elif len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    else:
+        raise click.BadParameter(
+            f"Expected 'name' or 'name,user_id,session_id', got: '{value}'"
+        )
+
+
+def _build_seg_uri(name: str, session_id, user_id, voxel_size: float) -> str:
+    if session_id is None and user_id is None:
+        return f"{name}@{voxel_size}"
+    elif session_id is None:
+        return f"{name}:{user_id}@{voxel_size}"
+    return f"{name}:{user_id}/{session_id}@{voxel_size}"
+
+
+def run_to_case_id(run_name: str) -> str:
+    """Sanitize a CoPick run name into a valid nnUNet case identifier."""
+    return run_name.replace("-", "_").replace(" ", "_")
+
+
+def array_to_nifti(data: np.ndarray, voxel_size_angstrom: float):
+    """
+    Wrap a (Z, Y, X) numpy array in a SimpleITK image.
+
+    Spacing is converted from Angstroms to nanometres (÷10) so that
+    nnUNet's patch-size planner sees reasonable numbers.
+    """
+    import SimpleITK as sitk
+
+    spacing_nm = float(voxel_size_angstrom) / 10.0
+    img = sitk.GetImageFromArray(data)
+    img.SetSpacing([spacing_nm, spacing_nm, spacing_nm])
+    return img
+
+
+def get_label_map(copick_config: str, seg_name: str, user_id: str, session_id: str) -> dict:
+    """Return {class_name: integer_label} from the targets config stored in the CoPick overlay."""
+    from copick_torch.nnunet.utils import get_config
+
+    target_cfg = get_config(copick_config, seg_name, "targets", user_id, session_id)
+    labels = {"background": 0}
+    for name, idx in target_cfg["input"]["labels"].items():
+        labels[name] = idx
+    return labels
+
+
+def load_volume(root, vol_uri: str, run_name: str) -> np.ndarray:
+    from copick.util.uri import resolve_copick_objects
+
+    vols = resolve_copick_objects(vol_uri, root, "tomogram", run_name=run_name)
+    if not vols:
+        raise RuntimeError(f"No tomogram found for run '{run_name}' with URI '{vol_uri}'")
+    return vols[0].numpy()
+
+
+def load_segmentation(root, seg_uri: str, run_name: str) -> np.ndarray:
+    from copick.util.uri import resolve_copick_objects
+
+    segs = resolve_copick_objects(seg_uri, root, "segmentation", run_name=run_name)
+    if not segs:
+        raise RuntimeError(f"No segmentation found for run '{run_name}' with URI '{seg_uri}'")
+    return segs[0].numpy().astype(np.uint8)
+
+
+def _process_train_run(args):
+    """Worker: load one training tomogram + segmentation and write nii.gz files."""
+    run_name, root, vol_uri, seg_uri, voxel_size, images_tr, labels_tr = args
+    import SimpleITK as sitk
+
+    case_id = run_to_case_id(run_name)
+    try:
+        tomo_data = load_volume(root, vol_uri, run_name)
+        seg_data  = load_segmentation(root, seg_uri, run_name)
+    except RuntimeError as e:
+        return run_name, False, str(e)
+
+    sitk.WriteImage(
+        array_to_nifti(tomo_data.astype(np.float32), voxel_size),
+        str(images_tr / f"{case_id}_0000.nii.gz"),
+    )
+    sitk.WriteImage(
+        array_to_nifti(seg_data, voxel_size),
+        str(labels_tr / f"{case_id}.nii.gz"),
+    )
+    return run_name, True, None
+
+
+def _process_test_run(args):
+    """Worker: load one test tomogram and write nii.gz file."""
+    run_name, root, vol_uri, voxel_size, images_ts = args
+    import SimpleITK as sitk
+
+    case_id = run_to_case_id(run_name)
+    try:
+        tomo_data = load_volume(root, vol_uri, run_name)
+    except RuntimeError as e:
+        return run_name, False, str(e)
+
+    sitk.WriteImage(
+        array_to_nifti(tomo_data.astype(np.float32), voxel_size),
+        str(images_ts / f"{case_id}_0000.nii.gz"),
+    )
+    return run_name, True, None
+
+
+def convert(cfg: dict):
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from pathlib import Path
+    from tqdm import tqdm
+    import copick
+    import json
+
+    copick_cfg   = cfg["copick_config"]
+    tomo_uri     = cfg["tomo_uri"]
+    voxel_size   = float(tomo_uri.split("@")[1])
+    seg_name, user_id, session_id = cfg["seg_info"]
+    num_workers  = cfg.get("num_workers", 4)
+
+    train_run_ids = [str(r) for r in (cfg.get("train_run_ids") or [])]
+    test_run_ids  = [str(r) for r in (cfg.get("test_run_ids")  or [])]
+
+    dataset_id   = cfg["dataset_id"]
+    dataset_name = cfg["dataset_name"]
+    nnunet_raw   = Path(cfg["nnunet_raw"])
+
+    vol_uri = tomo_uri
+    seg_uri = _build_seg_uri(seg_name, session_id, user_id, voxel_size)
+
+    dataset_dir = nnunet_raw / f"Dataset{dataset_id:03d}_{dataset_name}"
+    images_tr   = dataset_dir / "imagesTr"
+    labels_tr   = dataset_dir / "labelsTr"
+    images_ts   = dataset_dir / "imagesTs"
+
+    for d in [images_tr, labels_tr, images_ts]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    root = copick.from_file(copick_cfg)
+    all_runs = [r.name for r in root.runs]
+
+    if not train_run_ids:
+        train_run_ids = [r for r in all_runs if r not in test_run_ids]
+
+    labels_dict = get_label_map(copick_cfg, seg_name, user_id, session_id)
+
+    n_training = 0
+    skipped    = []
+    print(f"Attempting to convert {len(train_run_ids)} training runs "
+          f"(tomo={vol_uri}, seg={seg_uri}, num_workers={num_workers})...")
+    train_args = [
+        (run_name, root, vol_uri, seg_uri, voxel_size, images_tr, labels_tr)
+        for run_name in train_run_ids
+    ]
+    with ThreadPoolExecutor(max_workers=num_workers) as pool:
+        futures = {pool.submit(_process_train_run, a): a[0] for a in train_args}
+        for fut in tqdm(as_completed(futures), total=len(futures)):
+            run_name, ok, err = fut.result()
+            if ok:
+                n_training += 1
+            else:
+                print(f"  [SKIP] {err}")
+                skipped.append(run_name)
+
+    if n_training == 0:
+        import sys
+        print(
+            f"\n[ERROR] No training cases were written. "
+            f"Check that runs have both a tomogram matching '{vol_uri}' "
+            f"and a segmentation matching '{seg_uri}'."
+        )
+        sys.exit(1)
+
+    if test_run_ids:
+        print(f"\nConverting {len(test_run_ids)} test runs (num_workers={num_workers})...")
+        test_args = [
+            (run_name, root, vol_uri, voxel_size, images_ts)
+            for run_name in test_run_ids
+        ]
+        with ThreadPoolExecutor(max_workers=num_workers) as pool:
+            futures = {pool.submit(_process_test_run, a): a[0] for a in test_args}
+            for fut in tqdm(as_completed(futures), total=len(futures)):
+                run_name, ok, err = fut.result()
+                if not ok:
+                    print(f"  [SKIP] {err}")
+
+    dataset_json = {
+        "channel_names": {"0": "cryo-ET"},
+        "labels": labels_dict,
+        "numTraining": n_training,
+        "file_ending": ".nii.gz",
+    }
+    with open(dataset_dir / "dataset.json", "w") as f:
+        json.dump(dataset_json, f, indent=4)
+
+    print(f"\nDone. Dataset written to: {dataset_dir}")
+    print(f"  Training cases : {n_training}  (skipped: {len(skipped)})")
+    print(f"  Test cases     : {len(test_run_ids)}")
+    print(f"  Labels         : {labels_dict}")
+    if skipped:
+        print(f"  Skipped runs   : {skipped}")
+
+
+@click.command("nnunet", no_args_is_help=True)
+@click.option("-c", "--config", required=True, type=click.Path(exists=True),
+              help="Path to copick config.json")
+@click.option("-uri", "--tomo-uri", type=str, default="wbp@10.0",
+              help="Tomogram URI to use for training")
+@click.option("-sinfo", "--seg-info", type=str, default="targets",
+              callback=lambda ctx, param, value: _parse_target(value) if value else value,
+              help="Segmentation info as 'name' or 'name,user_id,session_id'")
+@click.option("-truns", "--train-run-ids", type=str, default=None,
+              callback=lambda ctx, param, value: _parse_list(value) if value else None,
+              help="Training run IDs, e.g. run1,run2,run3. Default: all runs not in test set.")
+@click.option("-tests", "--test-run-ids", type=str, default=None,
+              callback=lambda ctx, param, value: _parse_list(value) if value else None,
+              help="Test run IDs, e.g. run4,run5")
+@click.option("-did", "--dataset-id", type=int, required=False, default=1,
+              help="nnUNet dataset ID (integer; becomes Dataset{id}_{name})")
+@click.option("-dname", "--dataset-name", type=str, required=True,
+              help="nnUNet dataset name")
+@click.option("-raw", "--raw", "nnunet_raw", type=click.Path(), required=True,
+              help="Path to nnunet_raw output directory")
+@click.option("-j", "--num-workers", default=4, show_default=True, type=int,
+              help="Number of parallel worker threads for converting tomograms.")
+def cli(config, tomo_uri, seg_info, train_run_ids, test_run_ids,
+        dataset_id, dataset_name, nnunet_raw, num_workers):
+    """Convert a CoPick project to nnUNet raw dataset format (imagesTr / labelsTr / imagesTs)."""
+    cfg = {
+        "copick_config":  config,
+        "tomo_uri":       tomo_uri,
+        "seg_info":       seg_info,
+        "dataset_id":     dataset_id,
+        "dataset_name":   dataset_name,
+        "nnunet_raw":     nnunet_raw,
+        "train_run_ids":  train_run_ids or [],
+        "test_run_ids":   test_run_ids or [],
+        "num_workers":    num_workers,
+    }
+    convert(cfg)

--- a/copick_torch/nnunet/prepare.py
+++ b/copick_torch/nnunet/prepare.py
@@ -52,7 +52,7 @@ def array_to_nifti(data: np.ndarray, voxel_size_angstrom: float):
     Spacing is converted from Angstroms to nanometres (÷10) so that
     nnUNet's patch-size planner sees reasonable numbers.
     """
-    import SimpleITK as sitk
+    import SimpleITK as sitk  # noqa: N813
 
     spacing_nm = float(voxel_size_angstrom) / 10.0
     img = sitk.GetImageFromArray(data)
@@ -92,7 +92,7 @@ def load_segmentation(root, seg_uri: str, run_name: str) -> np.ndarray:
 def _process_train_run(args):
     """Worker: load one training tomogram + segmentation and write nii.gz files."""
     run_name, root, vol_uri, seg_uri, voxel_size, images_tr, labels_tr = args
-    import SimpleITK as sitk
+    import SimpleITK as sitk  # noqa: N813
 
     case_id = run_to_case_id(run_name)
     try:
@@ -115,7 +115,7 @@ def _process_train_run(args):
 def _process_test_run(args):
     """Worker: load one test tomogram and write nii.gz file."""
     run_name, root, vol_uri, voxel_size, images_ts = args
-    import SimpleITK as sitk
+    import SimpleITK as sitk  # noqa: N813
 
     case_id = run_to_case_id(run_name)
     try:
@@ -174,7 +174,7 @@ def convert(cfg: dict):
     skipped = []
     print(
         f"Attempting to convert {len(train_run_ids)} training runs "
-        f"(tomo={vol_uri}, seg={seg_uri}, num_workers={num_workers})..."
+        f"(tomo={vol_uri}, seg={seg_uri}, num_workers={num_workers})...",
     )
     train_args = [(run_name, root, vol_uri, seg_uri, voxel_size, images_tr, labels_tr) for run_name in train_run_ids]
     with ThreadPoolExecutor(max_workers=num_workers) as pool:
@@ -261,7 +261,12 @@ def convert(cfg: dict):
 )
 @click.option("-dname", "--dataset-name", type=str, required=True, help="nnUNet dataset name")
 @click.option(
-    "-raw", "--raw", "nnunet_raw", type=click.Path(), required=True, help="Path to nnunet_raw output directory"
+    "-raw",
+    "--raw",
+    "nnunet_raw",
+    type=click.Path(),
+    required=True,
+    help="Path to nnunet_raw output directory",
 )
 @click.option(
     "-j",

--- a/copick_torch/nnunet/prepare.py
+++ b/copick_torch/nnunet/prepare.py
@@ -11,6 +11,7 @@ Reads tomograms and segmentation masks from CoPick and writes them as
         ├── labelsTr/   {case}.nii.gz
         └── imagesTs/   {case}_0000.nii.gz   (if test_run_ids provided)
 """
+
 import click
 import numpy as np
 
@@ -27,7 +28,7 @@ def _parse_target(value: str) -> tuple:
         return parts[0], parts[1], parts[2]
     else:
         raise click.BadParameter(
-            f"Expected 'name' or 'name,user_id,session_id', got: '{value}'"
+            f"Expected 'name' or 'name,user_id,session_id', got: '{value}'",
         )
 
 
@@ -96,7 +97,7 @@ def _process_train_run(args):
     case_id = run_to_case_id(run_name)
     try:
         tomo_data = load_volume(root, vol_uri, run_name)
-        seg_data  = load_segmentation(root, seg_uri, run_name)
+        seg_data = load_segmentation(root, seg_uri, run_name)
     except RuntimeError as e:
         return run_name, False, str(e)
 
@@ -130,32 +131,33 @@ def _process_test_run(args):
 
 
 def convert(cfg: dict):
+    import json
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from pathlib import Path
-    from tqdm import tqdm
-    import copick
-    import json
 
-    copick_cfg   = cfg["copick_config"]
-    tomo_uri     = cfg["tomo_uri"]
-    voxel_size   = float(tomo_uri.split("@")[1])
+    import copick
+    from tqdm import tqdm
+
+    copick_cfg = cfg["copick_config"]
+    tomo_uri = cfg["tomo_uri"]
+    voxel_size = float(tomo_uri.split("@")[1])
     seg_name, user_id, session_id = cfg["seg_info"]
-    num_workers  = cfg.get("num_workers", 4)
+    num_workers = cfg.get("num_workers", 4)
 
     train_run_ids = [str(r) for r in (cfg.get("train_run_ids") or [])]
-    test_run_ids  = [str(r) for r in (cfg.get("test_run_ids")  or [])]
+    test_run_ids = [str(r) for r in (cfg.get("test_run_ids") or [])]
 
-    dataset_id   = cfg["dataset_id"]
+    dataset_id = cfg["dataset_id"]
     dataset_name = cfg["dataset_name"]
-    nnunet_raw   = Path(cfg["nnunet_raw"])
+    nnunet_raw = Path(cfg["nnunet_raw"])
 
     vol_uri = tomo_uri
     seg_uri = _build_seg_uri(seg_name, session_id, user_id, voxel_size)
 
     dataset_dir = nnunet_raw / f"Dataset{dataset_id:03d}_{dataset_name}"
-    images_tr   = dataset_dir / "imagesTr"
-    labels_tr   = dataset_dir / "labelsTr"
-    images_ts   = dataset_dir / "imagesTs"
+    images_tr = dataset_dir / "imagesTr"
+    labels_tr = dataset_dir / "labelsTr"
+    images_ts = dataset_dir / "imagesTs"
 
     for d in [images_tr, labels_tr, images_ts]:
         d.mkdir(parents=True, exist_ok=True)
@@ -169,13 +171,12 @@ def convert(cfg: dict):
     labels_dict = get_label_map(copick_cfg, seg_name, user_id, session_id)
 
     n_training = 0
-    skipped    = []
-    print(f"Attempting to convert {len(train_run_ids)} training runs "
-          f"(tomo={vol_uri}, seg={seg_uri}, num_workers={num_workers})...")
-    train_args = [
-        (run_name, root, vol_uri, seg_uri, voxel_size, images_tr, labels_tr)
-        for run_name in train_run_ids
-    ]
+    skipped = []
+    print(
+        f"Attempting to convert {len(train_run_ids)} training runs "
+        f"(tomo={vol_uri}, seg={seg_uri}, num_workers={num_workers})..."
+    )
+    train_args = [(run_name, root, vol_uri, seg_uri, voxel_size, images_tr, labels_tr) for run_name in train_run_ids]
     with ThreadPoolExecutor(max_workers=num_workers) as pool:
         futures = {pool.submit(_process_train_run, a): a[0] for a in train_args}
         for fut in tqdm(as_completed(futures), total=len(futures)):
@@ -188,19 +189,17 @@ def convert(cfg: dict):
 
     if n_training == 0:
         import sys
+
         print(
             f"\n[ERROR] No training cases were written. "
             f"Check that runs have both a tomogram matching '{vol_uri}' "
-            f"and a segmentation matching '{seg_uri}'."
+            f"and a segmentation matching '{seg_uri}'.",
         )
         sys.exit(1)
 
     if test_run_ids:
         print(f"\nConverting {len(test_run_ids)} test runs (num_workers={num_workers})...")
-        test_args = [
-            (run_name, root, vol_uri, voxel_size, images_ts)
-            for run_name in test_run_ids
-        ]
+        test_args = [(run_name, root, vol_uri, voxel_size, images_ts) for run_name in test_run_ids]
         with ThreadPoolExecutor(max_workers=num_workers) as pool:
             futures = {pool.submit(_process_test_run, a): a[0] for a in test_args}
             for fut in tqdm(as_completed(futures), total=len(futures)):
@@ -226,39 +225,63 @@ def convert(cfg: dict):
 
 
 @click.command("nnunet", no_args_is_help=True)
-@click.option("-c", "--config", required=True, type=click.Path(exists=True),
-              help="Path to copick config.json")
-@click.option("-uri", "--tomo-uri", type=str, default="wbp@10.0",
-              help="Tomogram URI to use for training")
-@click.option("-sinfo", "--seg-info", type=str, default="targets",
-              callback=lambda ctx, param, value: _parse_target(value) if value else value,
-              help="Segmentation info as 'name' or 'name,user_id,session_id'")
-@click.option("-truns", "--train-run-ids", type=str, default=None,
-              callback=lambda ctx, param, value: _parse_list(value) if value else None,
-              help="Training run IDs, e.g. run1,run2,run3. Default: all runs not in test set.")
-@click.option("-tests", "--test-run-ids", type=str, default=None,
-              callback=lambda ctx, param, value: _parse_list(value) if value else None,
-              help="Test run IDs, e.g. run4,run5")
-@click.option("-did", "--dataset-id", type=int, required=False, default=1,
-              help="nnUNet dataset ID (integer; becomes Dataset{id}_{name})")
-@click.option("-dname", "--dataset-name", type=str, required=True,
-              help="nnUNet dataset name")
-@click.option("-raw", "--raw", "nnunet_raw", type=click.Path(), required=True,
-              help="Path to nnunet_raw output directory")
-@click.option("-j", "--num-workers", default=4, show_default=True, type=int,
-              help="Number of parallel worker threads for converting tomograms.")
-def cli(config, tomo_uri, seg_info, train_run_ids, test_run_ids,
-        dataset_id, dataset_name, nnunet_raw, num_workers):
+@click.option("-c", "--config", required=True, type=click.Path(exists=True), help="Path to copick config.json")
+@click.option("-uri", "--tomo-uri", type=str, default="wbp@10.0", help="Tomogram URI to use for training")
+@click.option(
+    "-sinfo",
+    "--seg-info",
+    type=str,
+    default="targets",
+    callback=lambda ctx, param, value: _parse_target(value) if value else value,
+    help="Segmentation info as 'name' or 'name,user_id,session_id'",
+)
+@click.option(
+    "-truns",
+    "--train-run-ids",
+    type=str,
+    default=None,
+    callback=lambda ctx, param, value: _parse_list(value) if value else None,
+    help="Training run IDs, e.g. run1,run2,run3. Default: all runs not in test set.",
+)
+@click.option(
+    "-tests",
+    "--test-run-ids",
+    type=str,
+    default=None,
+    callback=lambda ctx, param, value: _parse_list(value) if value else None,
+    help="Test run IDs, e.g. run4,run5",
+)
+@click.option(
+    "-did",
+    "--dataset-id",
+    type=int,
+    required=False,
+    default=1,
+    help="nnUNet dataset ID (integer; becomes Dataset{id}_{name})",
+)
+@click.option("-dname", "--dataset-name", type=str, required=True, help="nnUNet dataset name")
+@click.option(
+    "-raw", "--raw", "nnunet_raw", type=click.Path(), required=True, help="Path to nnunet_raw output directory"
+)
+@click.option(
+    "-j",
+    "--num-workers",
+    default=4,
+    show_default=True,
+    type=int,
+    help="Number of parallel worker threads for converting tomograms.",
+)
+def cli(config, tomo_uri, seg_info, train_run_ids, test_run_ids, dataset_id, dataset_name, nnunet_raw, num_workers):
     """Convert a CoPick project to nnUNet raw dataset format (imagesTr / labelsTr / imagesTs)."""
     cfg = {
-        "copick_config":  config,
-        "tomo_uri":       tomo_uri,
-        "seg_info":       seg_info,
-        "dataset_id":     dataset_id,
-        "dataset_name":   dataset_name,
-        "nnunet_raw":     nnunet_raw,
-        "train_run_ids":  train_run_ids or [],
-        "test_run_ids":   test_run_ids or [],
-        "num_workers":    num_workers,
+        "copick_config": config,
+        "tomo_uri": tomo_uri,
+        "seg_info": seg_info,
+        "dataset_id": dataset_id,
+        "dataset_name": dataset_name,
+        "nnunet_raw": nnunet_raw,
+        "train_run_ids": train_run_ids or [],
+        "test_run_ids": test_run_ids or [],
+        "num_workers": num_workers,
     }
     convert(cfg)

--- a/copick_torch/nnunet/train.py
+++ b/copick_torch/nnunet/train.py
@@ -1,0 +1,193 @@
+"""
+Run nnUNet planning, preprocessing, and training on a converted CoPick dataset.
+
+Expects the dataset to already exist in nnunet_raw (run `copick-torch nnunet prepare` first).
+
+Steps:
+  1. nnUNetv2_plan_and_preprocess  — fingerprint + patch-size planning
+  2. nnUNetv2_train                — train one model per requested fold
+
+Supported models (--model flag):
+  nnunet              Standard nnUNet               → nnUNetTrainer
+  resnecl             Residual Encoder Large        → nnUNetTrainer + nnUNetResEncUNetLPlans
+  mednext_s           MedNeXt Small,  kernel 3      → nnUNetTrainerMedNeXtS_kernel3
+  mednext_b           MedNeXt Base,   kernel 3      → nnUNetTrainerMedNeXtB_kernel3
+  mednext_m           MedNeXt Medium, kernel 3      → nnUNetTrainerMedNeXtM_kernel3
+  mednext_l           MedNeXt Large,  kernel 3      → nnUNetTrainerMedNeXtL_kernel3
+  mednext_s_k5        MedNeXt Small,  kernel 5      → nnUNetTrainerMedNeXtS_kernel5
+  mednext_b_k5        MedNeXt Base,   kernel 5      → nnUNetTrainerMedNeXtB_kernel5
+  mednext_m_k5        MedNeXt Medium, kernel 5      → nnUNetTrainerMedNeXtM_kernel5
+  mednext_l_k5        MedNeXt Large,  kernel 5      → nnUNetTrainerMedNeXtL_kernel5
+"""
+import click
+
+# MedNeXt trainers require: pip install git+https://github.com/MIC-DKFZ/MedNeXt.git
+# Trainer classes are defined in copick_torch/nnunet/mednext_trainer.py and auto-registered
+# into nnunetv2's trainer directory on first use.
+MODEL_TO_TRAINER = {
+    "nnunet":       "nnUNetTrainer",
+    "resnecl":      "nnUNetTrainer",
+    "mednext_s":    "nnUNetTrainerMedNeXtS_kernel3",
+    "mednext_b":    "nnUNetTrainerMedNeXtB_kernel3",
+    "mednext_m":    "nnUNetTrainerMedNeXtM_kernel3",
+    "mednext_l":    "nnUNetTrainerMedNeXtL_kernel3",
+    "mednext_s_k5": "nnUNetTrainerMedNeXtS_kernel5",
+    "mednext_b_k5": "nnUNetTrainerMedNeXtB_kernel5",
+    "mednext_m_k5": "nnUNetTrainerMedNeXtM_kernel5",
+    "mednext_l_k5": "nnUNetTrainerMedNeXtL_kernel5",
+}
+
+MEDNEXT_MODELS = {k for k in MODEL_TO_TRAINER if k.startswith("mednext")}
+
+
+def _parse_int_list(value: str) -> list[int]:
+    return [int(x) for x in value.strip("[]").split(",")]
+
+
+def resolve_trainer(cfg: dict, model_override: str | None) -> tuple[str, str]:
+    """Return (model_name, trainer_class). Priority: CLI flag > config key > 'nnunet' default."""
+    from copick_torch.nnunet.utils import check_mednext_installed
+    import sys
+
+    model = model_override or cfg.get("model", "nnunet")
+    if model not in MODEL_TO_TRAINER:
+        print(f"[ERROR] Unknown model '{model}'. Choose from: {list(MODEL_TO_TRAINER)}")
+        sys.exit(1)
+    if model in MEDNEXT_MODELS:
+        check_mednext_installed()
+    return model, MODEL_TO_TRAINER[model]
+
+
+def set_nnunet_env(cfg: dict) -> dict:
+    """Set the three nnUNet path environment variables and return the updated env."""
+    from pathlib import Path
+    import os
+
+    env = os.environ.copy()
+    env["nnUNet_raw"]          = str(cfg["nnunet_raw"])
+    env["nnUNet_preprocessed"] = str(cfg["nnunet_preprocessed"])
+    env["nnUNet_results"]      = str(cfg["nnunet_results"])
+
+    for key in ("nnunet_preprocessed", "nnunet_results"):
+        Path(cfg[key]).mkdir(parents=True, exist_ok=True)
+
+    return env
+
+
+def plan_and_preprocess(cfg: dict, env: dict, model: str):
+    from copick_torch.nnunet.utils import _run
+
+    cmd = [
+        "nnUNetv2_plan_and_preprocess",
+        "-d", str(cfg["dataset_id"]),
+        "-c", cfg.get("configuration", "3d_fullres"),
+        "--verify_dataset_integrity",
+    ]
+    if model == "resnecl":
+        cmd += ["-pl", "nnUNetPlannerResEncL"]
+    _run(cmd, env)
+
+
+def checkpoint_exists(cfg: dict, trainer: str, model: str, fold: int) -> bool:
+    from pathlib import Path
+
+    plans         = "nnUNetResEncUNetLPlans" if model == "resnecl" else "nnUNetPlans"
+    configuration = cfg.get("configuration", "3d_fullres")
+    dataset_dir   = f"Dataset{cfg['dataset_id']:03d}_{cfg['dataset_name']}"
+    checkpoint    = (
+        Path(cfg["nnunet_results"])
+        / dataset_dir
+        / f"{trainer}__{plans}__{configuration}"
+        / f"fold_{fold}"
+        / "checkpoint_latest.pth"
+    )
+    return checkpoint.exists()
+
+
+def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
+    from copick_torch.nnunet.utils import _scale_batch_size_for_ddp, _run
+    import shutil, sys
+
+    dataset_id    = cfg["dataset_id"]
+    configuration = cfg.get("configuration", "3d_fullres")
+    folds         = cfg.get("folds", [0])
+
+    nnunet_train_bin = shutil.which("nnUNetv2_train")
+    if nnunet_train_bin is None:
+        print("[ERROR] nnUNetv2_train not found on PATH. Is nnunetv2 installed?")
+        sys.exit(1)
+
+    if num_gpus > 1:
+        _scale_batch_size_for_ddp(cfg, model, num_gpus)
+
+        if "nnUNet_n_proc_da" not in env:
+            import os
+            total_cpu  = os.cpu_count() or 16
+            per_gpu_da = max(2, total_cpu // num_gpus)
+            env["nnUNet_n_proc_da"] = str(per_gpu_da)
+            print(f"  [DA workers] nnUNet_n_proc_da={per_gpu_da} ({total_cpu} CPUs ÷ {num_gpus} GPUs)")
+
+    print(f"Training with trainer: {trainer}" + (f" on {num_gpus} GPUs" if num_gpus > 1 else ""))
+    for fold in folds:
+        train_cmd = [
+            nnunet_train_bin,
+            str(dataset_id),
+            configuration,
+            str(fold),
+            "-tr", trainer,
+        ]
+        if model == "resnecl":
+            train_cmd += ["-p", "nnUNetResEncUNetLPlans"]
+        if num_gpus > 1:
+            train_cmd += ["-num_gpus", str(num_gpus)]
+        if checkpoint_exists(cfg, trainer, model, fold):
+            print(f"  [fold {fold}] Checkpoint found — resuming.")
+            train_cmd += ["--c"]
+
+        _run(train_cmd, env)
+
+
+@click.command("nnunet", no_args_is_help=True)
+@click.option("-id", "--dataset-id", type=int, required=False, default=1,
+              help="nnUNet dataset ID (must match the one used in prepare)")
+@click.option("-n", "--dataset-name", type=str, required=True,
+              help="nnUNet dataset name (must match the one used in prepare)")
+@click.option("-r", "--raw", "nnunet_raw", type=click.Path(), required=True,
+              help="Path to nnunet_raw directory")
+@click.option("-pre", "--preprocessed", type=click.Path(), required=True,
+              help="Path to nnunet_preprocessed directory")
+@click.option("-o", "--results", type=click.Path(), required=True,
+              help="Path to nnunet_results directory")
+@click.option("-cfg", "--configuration",
+              type=click.Choice(["3d_fullres", "3d_lowres", "3d_cascade_fullres"]),
+              default="3d_fullres", show_default=True,
+              help="nnUNet configuration to train")
+@click.option("-f", "--folds", type=str, default="0", show_default=True,
+              callback=lambda ctx, param, value: _parse_int_list(value) if value else [0],
+              help="Folds to train, e.g. 0 or 0,1,2,3,4")
+@click.option("-m", "--model", type=click.Choice(list(MODEL_TO_TRAINER)), default="nnunet",
+              show_default=True,
+              help="Model architecture to train. MedNeXt variants require nnunet-mednext.")
+@click.option("-skip", "--skip-preprocess", is_flag=True, default=False,
+              help="Skip nnUNetv2_plan_and_preprocess (useful if already done).")
+@click.option("-ngpus", "--num-gpus", default=1, show_default=True, type=int,
+              help="Number of GPUs for distributed training.")
+def cli(dataset_id, dataset_name, nnunet_raw, preprocessed, results,
+        configuration, folds, model, skip_preprocess, num_gpus):
+    """Plan, preprocess, and train nnUNet on a CoPick dataset."""
+    cfg = {
+        "dataset_id":          dataset_id,
+        "dataset_name":        dataset_name,
+        "nnunet_raw":          nnunet_raw,
+        "nnunet_preprocessed": preprocessed,
+        "nnunet_results":      results,
+        "configuration":       configuration,
+        "folds":               folds,
+    }
+    env            = set_nnunet_env(cfg)
+    model, trainer = resolve_trainer(cfg, model)
+
+    if not skip_preprocess:
+        plan_and_preprocess(cfg, env, model)
+
+    train(cfg, env, model, trainer, num_gpus=num_gpus)

--- a/copick_torch/nnunet/train.py
+++ b/copick_torch/nnunet/train.py
@@ -32,10 +32,10 @@ MODEL_TO_TRAINER = {
     "mednext_b": "nnUNetTrainerMedNeXtB_kernel3",
     "mednext_m": "nnUNetTrainerMedNeXtM_kernel3",
     "mednext_l": "nnUNetTrainerMedNeXtL_kernel3",
-    "mednext_s_k5": "nnUNetTrainerMedNeXtS_kernel5",
-    "mednext_b_k5": "nnUNetTrainerMedNeXtB_kernel5",
-    "mednext_m_k5": "nnUNetTrainerMedNeXtM_kernel5",
-    "mednext_l_k5": "nnUNetTrainerMedNeXtL_kernel5",
+    # "mednext_s_k5": "nnUNetTrainerMedNeXtS_kernel5",
+    # "mednext_b_k5": "nnUNetTrainerMedNeXtB_kernel5",
+    # "mednext_m_k5": "nnUNetTrainerMedNeXtM_kernel5",
+    # "mednext_l_k5": "nnUNetTrainerMedNeXtL_kernel5",
 }
 
 MEDNEXT_MODELS = {k for k in MODEL_TO_TRAINER if k.startswith("mednext")}
@@ -173,7 +173,7 @@ def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
 )
 @click.option("-r", "--raw", "nnunet_raw", type=click.Path(), required=True, help="Path to nnunet_raw directory")
 @click.option("-pre", "--preprocessed", type=click.Path(), required=True, help="Path to nnunet_preprocessed directory")
-@click.option("-o", "--results", type=click.Path(), required=True, help="Path to nnunet_results directory")
+@click.option("-o", "--output", type=click.Path(), required=True, help="Path to nnunet_results directory")
 @click.option(
     "-cfg",
     "--configuration",
@@ -197,7 +197,7 @@ def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
     type=click.Choice(list(MODEL_TO_TRAINER)),
     default="nnunet",
     show_default=True,
-    help="Model architecture to train. MedNeXt variants require nnunet-mednext.",
+    help="Model architecture to train.",
 )
 @click.option(
     "-skip",
@@ -206,25 +206,16 @@ def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
     default=False,
     help="Skip nnUNetv2_plan_and_preprocess (useful if already done).",
 )
-@click.option(
-    "-ngpus",
-    "--num-gpus",
-    default=1,
-    show_default=True,
-    type=int,
-    help="Number of GPUs for distributed training.",
-)
 def cli(
     dataset_id,
     dataset_name,
     nnunet_raw,
     preprocessed,
-    results,
+    output,
     configuration,
     folds,
     model,
     skip_preprocess,
-    num_gpus,
 ):
     """Plan, preprocess, and train nnUNet on a CoPick dataset."""
     cfg = {
@@ -232,7 +223,7 @@ def cli(
         "dataset_name": dataset_name,
         "nnunet_raw": nnunet_raw,
         "nnunet_preprocessed": preprocessed,
-        "nnunet_results": results,
+        "nnunet_results": output,
         "configuration": configuration,
         "folds": folds,
     }
@@ -242,4 +233,4 @@ def cli(
     if not skip_preprocess:
         plan_and_preprocess(cfg, env, model)
 
-    train(cfg, env, model, trainer, num_gpus=num_gpus)
+    train(cfg, env, model, trainer, num_gpus=1)

--- a/copick_torch/nnunet/train.py
+++ b/copick_torch/nnunet/train.py
@@ -19,18 +19,19 @@ Supported models (--model flag):
   mednext_m_k5        MedNeXt Medium, kernel 5      → nnUNetTrainerMedNeXtM_kernel5
   mednext_l_k5        MedNeXt Large,  kernel 5      → nnUNetTrainerMedNeXtL_kernel5
 """
+
 import click
 
 # MedNeXt trainers require: pip install git+https://github.com/MIC-DKFZ/MedNeXt.git
 # Trainer classes are defined in copick_torch/nnunet/mednext_trainer.py and auto-registered
 # into nnunetv2's trainer directory on first use.
 MODEL_TO_TRAINER = {
-    "nnunet":       "nnUNetTrainer",
-    "resnecl":      "nnUNetTrainer",
-    "mednext_s":    "nnUNetTrainerMedNeXtS_kernel3",
-    "mednext_b":    "nnUNetTrainerMedNeXtB_kernel3",
-    "mednext_m":    "nnUNetTrainerMedNeXtM_kernel3",
-    "mednext_l":    "nnUNetTrainerMedNeXtL_kernel3",
+    "nnunet": "nnUNetTrainer",
+    "resnecl": "nnUNetTrainer",
+    "mednext_s": "nnUNetTrainerMedNeXtS_kernel3",
+    "mednext_b": "nnUNetTrainerMedNeXtB_kernel3",
+    "mednext_m": "nnUNetTrainerMedNeXtM_kernel3",
+    "mednext_l": "nnUNetTrainerMedNeXtL_kernel3",
     "mednext_s_k5": "nnUNetTrainerMedNeXtS_kernel5",
     "mednext_b_k5": "nnUNetTrainerMedNeXtB_kernel5",
     "mednext_m_k5": "nnUNetTrainerMedNeXtM_kernel5",
@@ -46,8 +47,9 @@ def _parse_int_list(value: str) -> list[int]:
 
 def resolve_trainer(cfg: dict, model_override: str | None) -> tuple[str, str]:
     """Return (model_name, trainer_class). Priority: CLI flag > config key > 'nnunet' default."""
-    from copick_torch.nnunet.utils import check_mednext_installed
     import sys
+
+    from copick_torch.nnunet.utils import check_mednext_installed
 
     model = model_override or cfg.get("model", "nnunet")
     if model not in MODEL_TO_TRAINER:
@@ -60,13 +62,13 @@ def resolve_trainer(cfg: dict, model_override: str | None) -> tuple[str, str]:
 
 def set_nnunet_env(cfg: dict) -> dict:
     """Set the three nnUNet path environment variables and return the updated env."""
-    from pathlib import Path
     import os
+    from pathlib import Path
 
     env = os.environ.copy()
-    env["nnUNet_raw"]          = str(cfg["nnunet_raw"])
+    env["nnUNet_raw"] = str(cfg["nnunet_raw"])
     env["nnUNet_preprocessed"] = str(cfg["nnunet_preprocessed"])
-    env["nnUNet_results"]      = str(cfg["nnunet_results"])
+    env["nnUNet_results"] = str(cfg["nnunet_results"])
 
     for key in ("nnunet_preprocessed", "nnunet_results"):
         Path(cfg[key]).mkdir(parents=True, exist_ok=True)
@@ -79,8 +81,10 @@ def plan_and_preprocess(cfg: dict, env: dict, model: str):
 
     cmd = [
         "nnUNetv2_plan_and_preprocess",
-        "-d", str(cfg["dataset_id"]),
-        "-c", cfg.get("configuration", "3d_fullres"),
+        "-d",
+        str(cfg["dataset_id"]),
+        "-c",
+        cfg.get("configuration", "3d_fullres"),
         "--verify_dataset_integrity",
     ]
     if model == "resnecl":
@@ -91,10 +95,10 @@ def plan_and_preprocess(cfg: dict, env: dict, model: str):
 def checkpoint_exists(cfg: dict, trainer: str, model: str, fold: int) -> bool:
     from pathlib import Path
 
-    plans         = "nnUNetResEncUNetLPlans" if model == "resnecl" else "nnUNetPlans"
+    plans = "nnUNetResEncUNetLPlans" if model == "resnecl" else "nnUNetPlans"
     configuration = cfg.get("configuration", "3d_fullres")
-    dataset_dir   = f"Dataset{cfg['dataset_id']:03d}_{cfg['dataset_name']}"
-    checkpoint    = (
+    dataset_dir = f"Dataset{cfg['dataset_id']:03d}_{cfg['dataset_name']}"
+    checkpoint = (
         Path(cfg["nnunet_results"])
         / dataset_dir
         / f"{trainer}__{plans}__{configuration}"
@@ -105,12 +109,14 @@ def checkpoint_exists(cfg: dict, trainer: str, model: str, fold: int) -> bool:
 
 
 def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
-    from copick_torch.nnunet.utils import _scale_batch_size_for_ddp, _run
-    import shutil, sys
+    import shutil
+    import sys
 
-    dataset_id    = cfg["dataset_id"]
+    from copick_torch.nnunet.utils import _run, _scale_batch_size_for_ddp
+
+    dataset_id = cfg["dataset_id"]
     configuration = cfg.get("configuration", "3d_fullres")
-    folds         = cfg.get("folds", [0])
+    folds = cfg.get("folds", [0])
 
     nnunet_train_bin = shutil.which("nnUNetv2_train")
     if nnunet_train_bin is None:
@@ -122,7 +128,8 @@ def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
 
         if "nnUNet_n_proc_da" not in env:
             import os
-            total_cpu  = os.cpu_count() or 16
+
+            total_cpu = os.cpu_count() or 16
             per_gpu_da = max(2, total_cpu // num_gpus)
             env["nnUNet_n_proc_da"] = str(per_gpu_da)
             print(f"  [DA workers] nnUNet_n_proc_da={per_gpu_da} ({total_cpu} CPUs ÷ {num_gpus} GPUs)")
@@ -134,7 +141,8 @@ def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
             str(dataset_id),
             configuration,
             str(fold),
-            "-tr", trainer,
+            "-tr",
+            trainer,
         ]
         if model == "resnecl":
             train_cmd += ["-p", "nnUNetResEncUNetLPlans"]
@@ -148,43 +156,69 @@ def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
 
 
 @click.command("nnunet", no_args_is_help=True)
-@click.option("-id", "--dataset-id", type=int, required=False, default=1,
-              help="nnUNet dataset ID (must match the one used in prepare)")
-@click.option("-n", "--dataset-name", type=str, required=True,
-              help="nnUNet dataset name (must match the one used in prepare)")
-@click.option("-r", "--raw", "nnunet_raw", type=click.Path(), required=True,
-              help="Path to nnunet_raw directory")
-@click.option("-pre", "--preprocessed", type=click.Path(), required=True,
-              help="Path to nnunet_preprocessed directory")
-@click.option("-o", "--results", type=click.Path(), required=True,
-              help="Path to nnunet_results directory")
-@click.option("-cfg", "--configuration",
-              type=click.Choice(["3d_fullres", "3d_lowres", "3d_cascade_fullres"]),
-              default="3d_fullres", show_default=True,
-              help="nnUNet configuration to train")
-@click.option("-f", "--folds", type=str, default="0", show_default=True,
-              callback=lambda ctx, param, value: _parse_int_list(value) if value else [0],
-              help="Folds to train, e.g. 0 or 0,1,2,3,4")
-@click.option("-m", "--model", type=click.Choice(list(MODEL_TO_TRAINER)), default="nnunet",
-              show_default=True,
-              help="Model architecture to train. MedNeXt variants require nnunet-mednext.")
-@click.option("-skip", "--skip-preprocess", is_flag=True, default=False,
-              help="Skip nnUNetv2_plan_and_preprocess (useful if already done).")
-@click.option("-ngpus", "--num-gpus", default=1, show_default=True, type=int,
-              help="Number of GPUs for distributed training.")
-def cli(dataset_id, dataset_name, nnunet_raw, preprocessed, results,
-        configuration, folds, model, skip_preprocess, num_gpus):
+@click.option(
+    "-id",
+    "--dataset-id",
+    type=int,
+    required=False,
+    default=1,
+    help="nnUNet dataset ID (must match the one used in prepare)",
+)
+@click.option(
+    "-n", "--dataset-name", type=str, required=True, help="nnUNet dataset name (must match the one used in prepare)"
+)
+@click.option("-r", "--raw", "nnunet_raw", type=click.Path(), required=True, help="Path to nnunet_raw directory")
+@click.option("-pre", "--preprocessed", type=click.Path(), required=True, help="Path to nnunet_preprocessed directory")
+@click.option("-o", "--results", type=click.Path(), required=True, help="Path to nnunet_results directory")
+@click.option(
+    "-cfg",
+    "--configuration",
+    type=click.Choice(["3d_fullres", "3d_lowres", "3d_cascade_fullres"]),
+    default="3d_fullres",
+    show_default=True,
+    help="nnUNet configuration to train",
+)
+@click.option(
+    "-f",
+    "--folds",
+    type=str,
+    default="0",
+    show_default=True,
+    callback=lambda ctx, param, value: _parse_int_list(value) if value else [0],
+    help="Folds to train, e.g. 0 or 0,1,2,3,4",
+)
+@click.option(
+    "-m",
+    "--model",
+    type=click.Choice(list(MODEL_TO_TRAINER)),
+    default="nnunet",
+    show_default=True,
+    help="Model architecture to train. MedNeXt variants require nnunet-mednext.",
+)
+@click.option(
+    "-skip",
+    "--skip-preprocess",
+    is_flag=True,
+    default=False,
+    help="Skip nnUNetv2_plan_and_preprocess (useful if already done).",
+)
+@click.option(
+    "-ngpus", "--num-gpus", default=1, show_default=True, type=int, help="Number of GPUs for distributed training."
+)
+def cli(
+    dataset_id, dataset_name, nnunet_raw, preprocessed, results, configuration, folds, model, skip_preprocess, num_gpus
+):
     """Plan, preprocess, and train nnUNet on a CoPick dataset."""
     cfg = {
-        "dataset_id":          dataset_id,
-        "dataset_name":        dataset_name,
-        "nnunet_raw":          nnunet_raw,
+        "dataset_id": dataset_id,
+        "dataset_name": dataset_name,
+        "nnunet_raw": nnunet_raw,
         "nnunet_preprocessed": preprocessed,
-        "nnunet_results":      results,
-        "configuration":       configuration,
-        "folds":               folds,
+        "nnunet_results": results,
+        "configuration": configuration,
+        "folds": folds,
     }
-    env            = set_nnunet_env(cfg)
+    env = set_nnunet_env(cfg)
     model, trainer = resolve_trainer(cfg, model)
 
     if not skip_preprocess:

--- a/copick_torch/nnunet/train.py
+++ b/copick_torch/nnunet/train.py
@@ -165,7 +165,11 @@ def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
     help="nnUNet dataset ID (must match the one used in prepare)",
 )
 @click.option(
-    "-n", "--dataset-name", type=str, required=True, help="nnUNet dataset name (must match the one used in prepare)"
+    "-n",
+    "--dataset-name",
+    type=str,
+    required=True,
+    help="nnUNet dataset name (must match the one used in prepare)",
 )
 @click.option("-r", "--raw", "nnunet_raw", type=click.Path(), required=True, help="Path to nnunet_raw directory")
 @click.option("-pre", "--preprocessed", type=click.Path(), required=True, help="Path to nnunet_preprocessed directory")
@@ -203,10 +207,24 @@ def train(cfg: dict, env: dict, model: str, trainer: str, num_gpus: int = 1):
     help="Skip nnUNetv2_plan_and_preprocess (useful if already done).",
 )
 @click.option(
-    "-ngpus", "--num-gpus", default=1, show_default=True, type=int, help="Number of GPUs for distributed training."
+    "-ngpus",
+    "--num-gpus",
+    default=1,
+    show_default=True,
+    type=int,
+    help="Number of GPUs for distributed training.",
 )
 def cli(
-    dataset_id, dataset_name, nnunet_raw, preprocessed, results, configuration, folds, model, skip_preprocess, num_gpus
+    dataset_id,
+    dataset_name,
+    nnunet_raw,
+    preprocessed,
+    results,
+    configuration,
+    folds,
+    model,
+    skip_preprocess,
+    num_gpus,
 ):
     """Plan, preprocess, and train nnUNet on a CoPick dataset."""
     cfg = {

--- a/copick_torch/nnunet/utils.py
+++ b/copick_torch/nnunet/utils.py
@@ -1,5 +1,7 @@
-import subprocess, sys, yaml
+import subprocess
+import sys
 
+import yaml
 
 MEDNEXT_INSTALL = "pip install git+https://github.com/MIC-DKFZ/MedNeXt.git"
 
@@ -29,17 +31,13 @@ def _run(cmd: list[str], env: dict):
 
 def _register_mednext_trainer():
     """Copy copick-torch's MedNeXt trainer into nnunetv2's trainer discovery directory."""
+    import shutil
     from pathlib import Path
-    import shutil, nnunetv2
+
+    import nnunetv2
 
     src = Path(__file__).parent / "mednext_trainer.py"
-    dst = (
-        Path(nnunetv2.__path__[0])
-        / "training"
-        / "nnUNetTrainer"
-        / "variants"
-        / "nnUNetTrainerMedNeXt.py"
-    )
+    dst = Path(nnunetv2.__path__[0]) / "training" / "nnUNetTrainer" / "variants" / "nnUNetTrainerMedNeXt.py"
 
     if not dst.exists():
         shutil.copy2(src, dst)
@@ -55,13 +53,13 @@ def _scale_batch_size_for_ddp(cfg: dict, model: str, num_gpus: int):
     so each GPU still processes the same number of samples (same memory footprint).
     The updated plans file is written back in-place; re-run plan_and_preprocess to reset.
     """
-    from pathlib import Path
     import json
+    from pathlib import Path
 
-    plans_name    = "nnUNetResEncUNetLPlans" if model == "resnecl" else "nnUNetPlans"
+    plans_name = "nnUNetResEncUNetLPlans" if model == "resnecl" else "nnUNetPlans"
     configuration = cfg.get("configuration", "3d_fullres")
-    dataset_dir   = f"Dataset{cfg['dataset_id']:03d}_{cfg['dataset_name']}"
-    plans_file    = Path(cfg["nnunet_preprocessed"]) / dataset_dir / f"{plans_name}.json"
+    dataset_dir = f"Dataset{cfg['dataset_id']:03d}_{cfg['dataset_name']}"
+    plans_file = Path(cfg["nnunet_preprocessed"]) / dataset_dir / f"{plans_name}.json"
 
     if not plans_file.exists():
         return
@@ -75,8 +73,8 @@ def _scale_batch_size_for_ddp(cfg: dict, model: str, num_gpus: int):
         return
 
     per_gpu_key = "_copick_torch_per_gpu_batch_size"
-    per_gpu_bs  = plans.get(per_gpu_key, current)
-    scaled      = per_gpu_bs * num_gpus
+    per_gpu_bs = plans.get(per_gpu_key, current)
+    scaled = per_gpu_bs * num_gpus
 
     if current == scaled:
         return
@@ -88,7 +86,7 @@ def _scale_batch_size_for_ddp(cfg: dict, model: str, num_gpus: int):
 
     print(
         f"  [plans] batch_size scaled {per_gpu_bs} → {scaled} "
-        f"({per_gpu_bs}/GPU × {num_gpus} GPUs, same per-GPU memory)."
+        f"({per_gpu_bs}/GPU × {num_gpus} GPUs, same per-GPU memory).",
     )
 
 
@@ -110,13 +108,15 @@ def save_parameters_yaml(params: dict, output_path: str):
 
     _SmartDumper.add_representer(list, _represent_list)
     with open(output_path, "w") as f:
-        yaml.dump(params, f, Dumper=_SmartDumper, default_flow_style=False,
-                  sort_keys=False, width=100, indent=2)
+        yaml.dump(params, f, Dumper=_SmartDumper, default_flow_style=False, sort_keys=False, width=100, indent=2)
 
 
 def get_config(config_path: str, name: str, process: str, user_id=None, session_id=None) -> dict:
     """Read a process config YAML from the CoPick overlay/static logs directory."""
-    import os, glob, copick
+    import glob
+    import os
+
+    import copick
 
     root = copick.from_file(config_path)
     overlay_root = remove_prefix(root.config.overlay_root)

--- a/copick_torch/nnunet/utils.py
+++ b/copick_torch/nnunet/utils.py
@@ -1,0 +1,144 @@
+import subprocess, sys, yaml
+
+
+MEDNEXT_INSTALL = "pip install git+https://github.com/MIC-DKFZ/MedNeXt.git"
+
+
+def check_mednext_installed():
+    try:
+        import nnunet_mednext  # noqa: F401
+    except ModuleNotFoundError:
+        print("[ERROR] MedNeXt is not installed. Run:")
+        print(f"  {MEDNEXT_INSTALL}")
+        sys.exit(1)
+    _register_mednext_trainer()
+
+
+def _load_config(path: str) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _run(cmd: list[str], env: dict):
+    print(f"\n>>> {' '.join(cmd)}\n")
+    result = subprocess.run(cmd, env=env)
+    if result.returncode != 0:
+        print(f"[ERROR] Command failed with return code {result.returncode}")
+        sys.exit(result.returncode)
+
+
+def _register_mednext_trainer():
+    """Copy copick-torch's MedNeXt trainer into nnunetv2's trainer discovery directory."""
+    from pathlib import Path
+    import shutil, nnunetv2
+
+    src = Path(__file__).parent / "mednext_trainer.py"
+    dst = (
+        Path(nnunetv2.__path__[0])
+        / "training"
+        / "nnUNetTrainer"
+        / "variants"
+        / "nnUNetTrainerMedNeXt.py"
+    )
+
+    if not dst.exists():
+        shutil.copy2(src, dst)
+        print("  [INFO] Registered MedNeXt trainer into nnUNet v2.")
+
+
+def _scale_batch_size_for_ddp(cfg: dict, model: str, num_gpus: int):
+    """
+    Scale the plans JSON batch_size to num_gpus × planned_per_gpu_batch_size.
+
+    nnUNet plans for single-GPU memory: batch_size=2 means 2 samples per GPU.
+    In DDP the global batch is split across GPUs, so we multiply by num_gpus
+    so each GPU still processes the same number of samples (same memory footprint).
+    The updated plans file is written back in-place; re-run plan_and_preprocess to reset.
+    """
+    from pathlib import Path
+    import json
+
+    plans_name    = "nnUNetResEncUNetLPlans" if model == "resnecl" else "nnUNetPlans"
+    configuration = cfg.get("configuration", "3d_fullres")
+    dataset_dir   = f"Dataset{cfg['dataset_id']:03d}_{cfg['dataset_name']}"
+    plans_file    = Path(cfg["nnunet_preprocessed"]) / dataset_dir / f"{plans_name}.json"
+
+    if not plans_file.exists():
+        return
+
+    with open(plans_file) as f:
+        plans = json.load(f)
+
+    try:
+        current = plans["configurations"][configuration]["batch_size"]
+    except KeyError:
+        return
+
+    per_gpu_key = "_copick_torch_per_gpu_batch_size"
+    per_gpu_bs  = plans.get(per_gpu_key, current)
+    scaled      = per_gpu_bs * num_gpus
+
+    if current == scaled:
+        return
+
+    plans[per_gpu_key] = per_gpu_bs
+    plans["configurations"][configuration]["batch_size"] = scaled
+    with open(plans_file, "w") as f:
+        json.dump(plans, f, indent=4)
+
+    print(
+        f"  [plans] batch_size scaled {per_gpu_bs} → {scaled} "
+        f"({per_gpu_bs}/GPU × {num_gpus} GPUs, same per-GPU memory)."
+    )
+
+
+def remove_prefix(text: str) -> str:
+    if text is None:
+        return None
+    if text.startswith("local://"):
+        text = text[8:]
+    return text
+
+
+def save_parameters_yaml(params: dict, output_path: str):
+    class _SmartDumper(yaml.SafeDumper):
+        pass
+
+    def _represent_list(dumper, data):
+        flow = all(x is None or isinstance(x, (str, int, float, bool)) for x in data)
+        return dumper.represent_sequence("tag:yaml.org,2002:seq", data, flow_style=flow)
+
+    _SmartDumper.add_representer(list, _represent_list)
+    with open(output_path, "w") as f:
+        yaml.dump(params, f, Dumper=_SmartDumper, default_flow_style=False,
+                  sort_keys=False, width=100, indent=2)
+
+
+def get_config(config_path: str, name: str, process: str, user_id=None, session_id=None) -> dict:
+    """Read a process config YAML from the CoPick overlay/static logs directory."""
+    import os, glob, copick
+
+    root = copick.from_file(config_path)
+    overlay_root = remove_prefix(root.config.overlay_root)
+    try:
+        static_root = remove_prefix(root.config.static_root)
+    except Exception:
+        static_root = None
+
+    if session_id is None:
+        pattern = glob.glob(os.path.join(overlay_root, "logs", f"{process}_*{name}.yaml"))
+        if len(pattern) == 0 and static_root is not None:
+            pattern = glob.glob(os.path.join(static_root, "logs", f"{process}_*{name}.yaml"))
+        fname = pattern[-1]
+    else:
+        fname = f"{process}-{user_id}_{session_id}_{name}.yaml"
+
+    if os.path.exists(os.path.join(overlay_root, "logs", fname)):
+        path = os.path.join(overlay_root, "logs", fname)
+    elif static_root is not None and os.path.exists(os.path.join(static_root, "logs", fname)):
+        path = os.path.join(static_root, "logs", fname)
+    else:
+        raise FileNotFoundError(f"Target config file not found: {fname}")
+
+    with open(path) as f:
+        return yaml.safe_load(f)

--- a/copick_torch/nnunet/utils.py
+++ b/copick_torch/nnunet/utils.py
@@ -125,11 +125,19 @@ def get_config(config_path: str, name: str, process: str, user_id=None, session_
     except Exception:
         static_root = None
 
+    # First chance: search for the most recent file matching the target name
     if session_id is None:
-        pattern = glob.glob(os.path.join(overlay_root, "logs", f"{process}_*{name}.yaml"))
+
+        # First chance: search for the most recent file matching the target name in the overlay root
+        pattern = glob.glob(os.path.join(overlay_root, "logs", f"{process}-*{name}.yaml"))
         if len(pattern) == 0 and static_root is not None:
-            pattern = glob.glob(os.path.join(static_root, "logs", f"{process}_*{name}.yaml"))
-        fname = pattern[-1]
+            pattern = glob.glob(os.path.join(static_root, "logs", f"{process}-*{name}.yaml"))
+
+        # Second chance: search for the most recent file matching the target name in the static root
+        if len(pattern) == 0:
+            raise FileNotFoundError(f"Target config file not found: {process}-*{name}.yaml")
+        else:
+            fname = pattern[-1]
     else:
         fname = f"{process}-{user_id}_{session_id}_{name}.yaml"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "zarr",
     "mrcfile",
     "gdown",
+    "nnunetv2",
+    "SimpleITK",    
     "membrain-seg",
     "numcodecs<0.16.0",
     "pandas>=2.2.3",
@@ -45,6 +47,7 @@ dependencies = [
     "scikit-learn>=1.6.1",
     "torchvision>=0.21.0",
 ]
+
 authors = [
     {name = "Kyle Harrington", email = "czi@kyleharrington.com"},
     { name = "Jonathan Schwartz", email = "jonathan.schwartz@czii.org" },
@@ -86,13 +89,18 @@ coverage-report = "scripts.coverage_report:main"
 [project.entry-points."copick.convert.commands"]
 picks2slab = "copick_torch.entry_points.run_picks2slab:picks2slab"
 seg2slab = "copick_torch.entry_points.run_seg2slab:seg2slab"
+nnunet = "copick_torch.nnunet.prepare:cli"
 
 [project.entry-points."copick.process.commands"]
 downsample = "copick_torch.entry_points.run_downsample:downsample"
 bandpass = "copick_torch.entry_points.run_filter3d:bandpass"
 
+[project.entry-points."copick.training.commands"]
+nnunet = "copick_torch.nnunet.train:cli"
+
 [project.entry-points."copick.inference.commands"]
 membrain-seg = "copick_torch.entry_points.run_membrane_seg:membrain_seg"
+nnunet = "copick_torch.nnunet.predict:cli"
 
 [tool.hatch.version]
 path = "copick_torch/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "mrcfile",
     "gdown",
     "nnunetv2",
-    "SimpleITK",    
+    "SimpleITK",
     "membrain-seg",
     "numcodecs<0.16.0",
     "pandas>=2.2.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -12,6 +12,21 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
+
+[[package]]
+name = "acvl-utils"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "batchgenerators" },
+    { name = "blosc2" },
+    { name = "connected-components-3d" },
+    { name = "numpy" },
+    { name = "scikit-image" },
+    { name = "simpleitk" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/7b/cac76bd8285369399be3ac2e29f3e4ef2b36fe3b75fe357825e481eee825/acvl_utils-0.2.6.tar.gz", hash = "sha256:d6bd68a916fb2451ab3dd640b2494e545edc204c839ae1d4dd49f88f89999b74", size = 34313, upload-time = "2026-04-09T12:03:44.893Z" }
 
 [[package]]
 name = "aiobotocore"
@@ -248,6 +263,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argparse"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/dd/e617cfc3f6210ae183374cd9f6a26b20514bbb5a792af97949c5aacddf0f/argparse-1.4.0.tar.gz", hash = "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4", size = 70508, upload-time = "2015-09-12T20:22:16.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/94/3af39d34be01a24a6e65433d19e107099374224905f1e0cc6bbe1fd22a2f/argparse-1.4.0-py2.py3-none-any.whl", hash = "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314", size = 23000, upload-time = "2015-09-14T16:03:16.137Z" },
+]
+
+[[package]]
 name = "arrow"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -325,6 +349,37 @@ wheels = [
 ]
 
 [[package]]
+name = "batchgenerators"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "future" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "scikit-image" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+    { name = "unittest2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f8/bff7e5eaf85b064a85bf8827a6bda04e92e2ff4d2e908c45033344886b44/batchgenerators-0.25.1.tar.gz", hash = "sha256:4663a7f393bf1681d7675648362ba3f11b2a9474fb17228a92aac5d1ad28bb39", size = 76970, upload-time = "2024-11-07T06:56:32.595Z" }
+
+[[package]]
+name = "batchgeneratorsv2"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "batchgenerators" },
+    { name = "numpy" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/7c/65bd7f955348c03db3d9a59379baab4a19f86579593fb8189f44dc257a17/batchgeneratorsv2-0.3.2.tar.gz", hash = "sha256:636215d7ce56c33033a86f97577cb0a97b1a5c6b245d4ae4597f664191281366", size = 51037, upload-time = "2026-04-09T12:05:38.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/8a/a45a6938f1619e340740f8df5b5f9aead8571d7e92322c6eb5021c74a792/batchgeneratorsv2-0.3.2-py3-none-any.whl", hash = "sha256:cc20db72d2f589baf14a2ce5290b138c99b8247b2b78a06f2c47f40910aadee1", size = 73738, upload-time = "2026-04-13T07:50:11.135Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -389,6 +444,46 @@ wheels = [
 [package.optional-dependencies]
 css = [
     { name = "tinycss2" },
+]
+
+[[package]]
+name = "blosc2"
+version = "4.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "ndindex" },
+    { name = "numexpr", marker = "platform_machine != 'wasm32'" },
+    { name = "numpy" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/fa/d72f624903dad1f2e95cb97d4e3777284f7eb398792f0d3380fdd73c1fc4/blosc2-4.1.2.tar.gz", hash = "sha256:c127342d976de44fee242137e83660097e0b072779f4164a34e149ac9f693c8a", size = 4341120, upload-time = "2026-03-03T11:05:14.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/85/1240460e27c82897608df1c3f4b9c9243019a2e2345215d5f04e1a36fb15/blosc2-4.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7f8cd9d95563fbd6a76eed81ba85669d11c53385fb01ee8a91bed3b8070fa661", size = 4641818, upload-time = "2026-03-03T11:04:36.099Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/51/a988a96be0cc8a7c187d26579c21770c0f679a1d12b6268629f554640e33/blosc2-4.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0dcddab7db4398c11190f21b48c2fe468d99b4a003bbacb30011c00be11d9c75", size = 4116600, upload-time = "2026-03-03T11:04:37.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b6/1c8b6b703d6f000df557ca594451883d18dcbe89b881fe1be75df82d76e7/blosc2-4.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09127cb9d32e2b0d04333ef9e50f7bcf00765f1a20216cede40a04f36d786069", size = 5094195, upload-time = "2026-03-03T11:04:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/2a/d71c52fae9ae60337ad34f872a8537d1329be028b7449951c8f61421298f/blosc2-4.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca2a8cdb85d6c3dc2ed19b550ee57041c9ea9230f9fa9829cfd0fe467fa6ad1d", size = 5229746, upload-time = "2026-03-03T11:04:40.669Z" },
+    { url = "https://files.pythonhosted.org/packages/50/3d/e29f14df0053c510ed75a3f8a7a1429b6e5e72f8e3928911d15f6b63fe36/blosc2-4.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:ab8e878763b8f19c284cca8854f312988cb8039181eda508a01a1174f97938c5", size = 3145620, upload-time = "2026-03-03T11:04:42.262Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/74/ef2f1cea5239062be872fe7db384fcb5f7532257efcec11c960a15a5134f/blosc2-4.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2f39bc24bfde0ba2938f23b3ecd6a69f7788c9e775c88e0be37a3b4680bc84c8", size = 4686887, upload-time = "2026-03-03T11:04:43.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/834a234879ae8bcb61be4bf88855e29f62d06da0b5b45a01f6e7898e9d5f/blosc2-4.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0bd7e752f636cde649f92acb735d58e23d0813ed9b24fb02f65eaaa7a415cdd", size = 4117160, upload-time = "2026-03-03T11:04:45.11Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d0/84d10472414a605bac9e794e03ff53ce464e22fe83edc365dc88b6833c14/blosc2-4.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ceb440269004619a416813b7c36abef94b028fd702dd8209b5d41311b6ce39c4", size = 5071905, upload-time = "2026-03-03T11:04:47.327Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c6/6c98cb75da1ef26cb27fedb3edb4b3cdd1b3aa2f1056bdd9de0823effed9/blosc2-4.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:830addc8d8722348421e5d99d719c53a36ff34a468980a7af05938ddb336cf4f", size = 5208010, upload-time = "2026-03-03T11:04:48.542Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d7/d4988cd88c070b2a24b446bf780fc43a7cb73a4af1e092b11edc832f616c/blosc2-4.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:9abc9432f7aa9335c87eb7b3cec72ac7bf3b764518e775b4f60159617e0817bf", size = 3147758, upload-time = "2026-03-03T11:04:49.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b2/3d0a6711f9376ed2e84e420c3c74656e51803420ed2d0df997b027b6fd2d/blosc2-4.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:572fda198a250ee5e2c6b52d0067805ffa0d46d7e22213fcc23917164c33b8e5", size = 4686973, upload-time = "2026-03-03T11:04:51.321Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/5d/caa4c7eeac59664dcce968c69823e2416bf4f184af0b89507f52c085a98e/blosc2-4.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:192f3508522ce8867cd9aee70782450eeb89eb2de882f16d563320362ddf145a", size = 4116819, upload-time = "2026-03-03T11:04:52.66Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ba/e038eec32caaf498f8d95e276c9a294895bf18419ba2504cee77bfec0008/blosc2-4.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:45075f00eb92e8d1abed1ea89038c9827ebd846d47e53c5c9988e22f7044f01f", size = 5071700, upload-time = "2026-03-03T11:04:53.856Z" },
+    { url = "https://files.pythonhosted.org/packages/59/74/394d53ac3b3583163f7cc5b43d59d457e6398d8f1b51b85bc9f7bd7cf430/blosc2-4.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f453b76764753c7c0ba3ce13ffcf0cefa191b0668adb28979f88cb9093ad7ae", size = 5208120, upload-time = "2026-03-03T11:04:55.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e2/d5b09cec0383381026c41fd071ae6a9342dfd70d0584aeae672e77dda82f/blosc2-4.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a72cc1fdc74744723092ccb63d03cf49c64f911450d2c9296182ce7bcda45d04", size = 3147727, upload-time = "2026-03-03T11:04:57.506Z" },
+    { url = "https://files.pythonhosted.org/packages/02/bf/20bc86e3eef536cf077be84c2b52583620ac877852962cf2d6c0281052ed/blosc2-4.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d8b7c45d537bfeb4b4c6d93c042ae4c07fe5aa6ce47d1acccb028802b2091d7", size = 4689092, upload-time = "2026-03-03T11:04:59.094Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f6/c0e9a30bdd151294203c933a2d612559548bdbd21e3ebfc4671982117f3d/blosc2-4.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9303b3e4a503a15cb4c42eb9c194a75a41603b879d89945967d72b5606857395", size = 4119002, upload-time = "2026-03-03T11:05:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/37/75/59a2b35ae875198528b2bd89015fc4f143e40f859749735395877d7fdf96/blosc2-4.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0dcd142b6ec74b69f9ccfc006a98ea3e91617b245c0455f894a41a03cd88bd73", size = 5076726, upload-time = "2026-03-03T11:05:02.189Z" },
+    { url = "https://files.pythonhosted.org/packages/24/98/c8c1e711d65e45c7109cd1ea90dd98d30dd2bc5d1c8d670fa91a5c563137/blosc2-4.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05551c7111e96095b88f7070ec36dacb892a7f8c52c7550c019c93f892c511a9", size = 5209021, upload-time = "2026-03-03T11:05:03.813Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/85/4457050893f21c0b3237ce2c279a63f7e6cbf9b86126a42f17f5b83cafe6/blosc2-4.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:68d04c8ea0ed1798baf0921b34434b564197c8a11569f5c64d9bea195329987c", size = 3220427, upload-time = "2026-03-03T11:05:05.689Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1c/18c47a98ba38a618f0cd3a1872d71b3db8553ce5466e7b5fd74b03dbe377/blosc2-4.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:52f69fd854cf2d9ce83cb0f6f214c6c9fb7f9149c24bd9af929482cbe95d3ff1", size = 4705783, upload-time = "2026-03-03T11:05:07.2Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/97/72ddd8146f8bd77026c1c28813e113c6b8a40b4f9bd4fe064f3618cebcd8/blosc2-4.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cdfb208850c082e629dbed2aa8ff0328b64bfca691fcfdd89141af20f5fcc908", size = 4141025, upload-time = "2026-03-03T11:05:08.781Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/43/537635bf12f258db17a1a80e56c39bfefce218e1baab5459c05a4ff9739f/blosc2-4.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:df3e78642af359f3bdc46f4446f0517f2deca2b3d4c9c92caf49d4abf6ce2a9c", size = 5061103, upload-time = "2026-03-03T11:05:10.475Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e3/ad7dff6eaf0e36a0959865ebd5a16026929f5a919cf0158858c307d6971d/blosc2-4.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:482e2f1447d47241af1952a563573cf12f67fcb86a2d87227dc28e427b29f865", size = 5195395, upload-time = "2026-03-03T11:05:11.768Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9e/b028eed46dfa45def2ca9c3e66aa3b8a3188a8a4998d017c699caf2bf0d9/blosc2-4.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9ee2217b03ecca4e823ff22701f423b7630f2b0a44773e0486ddbaa953ed39e9", size = 3243706, upload-time = "2026-03-03T11:05:13.294Z" },
 ]
 
 [[package]]
@@ -657,6 +752,46 @@ wheels = [
 ]
 
 [[package]]
+name = "connected-components-3d"
+version = "3.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c6/e5351e79dcec53b0e39f0e82653ab1d36254dd165adba265c72694c15349/connected_components_3d-3.28.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8a6a172edd0c0a2346344e659d986c91ebfaa4707d9d6c6bdc9b194f4d7dc300", size = 817425, upload-time = "2026-05-05T05:18:23.687Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/7b5916acca950ccbd36a0cb3978cae56b33b7c165aa3c7128b192907ee28/connected_components_3d-3.28.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:516c5f5b101894733f0e580f03e5c08f2752b2d966be8347463b3d1b8342926f", size = 709701, upload-time = "2026-05-05T05:18:25.253Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/53ad6a416dde111cfbf81cc71b3d90d5bb5809dea14fed5d619c64ae1af0/connected_components_3d-3.28.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5eec0e4586814aed8f82784d68a92daa8ac6752116af8a085da1a15837519618", size = 4356621, upload-time = "2026-05-05T05:18:26.84Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d6/9e17d145e281d6bbc4d8d0abb05a29fc8a14237379795630420f0b1d0e42/connected_components_3d-3.28.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c839aeb3aabbd954f801950aad8b21b5610ed48b6798fa457b7359610690df7", size = 4706909, upload-time = "2026-05-05T05:18:28.897Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b6/ef52cbb9ce8898ab918d6af2d6e3ac4f0ae83d14e1dccf19ce052133b74e/connected_components_3d-3.28.0-cp311-cp311-win32.whl", hash = "sha256:da573e2ec2a40f15538d346b2f0dea9e9bb55f3e9ce36541f5f5e724f242b4ae", size = 615652, upload-time = "2026-05-05T05:18:31.723Z" },
+    { url = "https://files.pythonhosted.org/packages/07/58/ce641a94549c28b262fd9c6eba6b8e27f143a558e087f703538bc1052fa4/connected_components_3d-3.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:3ad6d00a0f2948b99e0f253543ef1e9e634b6a55aaddbe7ee9f11d53d7c768fa", size = 534771, upload-time = "2026-05-05T05:18:30.445Z" },
+    { url = "https://files.pythonhosted.org/packages/06/68/971a9c04c49da5b17ed1b789467cb2c5450511cda18ef528b00314f1257e/connected_components_3d-3.28.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ea651d309f6961987fe569cc11cd8f94ba6922cc2cd25b731d9a6b466bdfd00c", size = 810874, upload-time = "2026-05-05T05:18:33.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/db1914168d5104fbd646990353c8e46750c63795da35914862e48537bbb6/connected_components_3d-3.28.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5dcfb534ccd716b7cc13052d62abb85ea3fb5cf6785cfc387e02620ab96e4b6f", size = 707539, upload-time = "2026-05-05T05:18:34.325Z" },
+    { url = "https://files.pythonhosted.org/packages/df/19/59e861733b05ea5a840985fe4e56e9f46b5139d5c35a034340fd9f73680e/connected_components_3d-3.28.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8feecc6d25aaedf91f7ab360b128c064ba4042aa074aa4d448b416fecc5a59d1", size = 4309643, upload-time = "2026-05-05T05:18:36.115Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ac/39aa8756ed7cb93bb302a1cc83915754d506a453cfc00c2308678ad39c43/connected_components_3d-3.28.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53351a24ea2c62a03cb1a079e47dfb1a2f65d66be47a96d3fba61b34ab16231f", size = 4702688, upload-time = "2026-05-05T05:18:38.183Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d3/46f6319c687351f35d3c9968fc9b07287945146ef57ffcbfc3d92a287261/connected_components_3d-3.28.0-cp312-cp312-win32.whl", hash = "sha256:b1fbe034305a6a7b5793c07fe349be2c10a407b6763c7914ff76041d08750609", size = 606578, upload-time = "2026-05-05T05:18:41.317Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/95/ed3ada4bbe1a0fa511993df74443d5f6a1b0d50abf44c808fc7f26c20745/connected_components_3d-3.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:229bf246414940bac91735d3070abb30e6c85f6bff5f1feab579b2fcd1657dd0", size = 520043, upload-time = "2026-05-05T05:18:39.694Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/27/f4bf63cff905c0d098dc8e9b1c6fadb0a894f65a6459c553673509e73e02/connected_components_3d-3.28.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2e8885357391d17084de2f91602bd1dc35c5b7a54407d7ca8fcc6454e309f69c", size = 809863, upload-time = "2026-05-05T05:18:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/900d5762fc39a8efb663228cdc918d536527c19a3ab276751be2453543f4/connected_components_3d-3.28.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:698940875236dc9ab52c5147c431098d2eb0f968c027fe907a4ae5579f33a4d3", size = 706682, upload-time = "2026-05-05T05:18:43.883Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/030d2014b6644232a4964a61c0a56fb98f6b58f20c979f9f9434eabaef9f/connected_components_3d-3.28.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60defae033f025c07f4c1fb183ebbed0097af50926f984eb3df4da884ba8a190", size = 4320633, upload-time = "2026-05-05T05:18:45.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a4/ff7ede7091d1c58316a789842861ceb7ad61110589688f8017f2d5f6aa73/connected_components_3d-3.28.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be127b1d3401f66202c053ab491cacc555f81bfac1df7632eda6a7844398a705", size = 4686763, upload-time = "2026-05-05T05:18:47.299Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/57/336c65f1409acd3ffd4cc15f2fcd8ed96f530f7a5775830fda03230498d9/connected_components_3d-3.28.0-cp313-cp313-win32.whl", hash = "sha256:960e9579c325e30fae145c8a2cccdbc57a104e3540b9002c874aa574d549bec8", size = 606482, upload-time = "2026-05-05T05:18:50.327Z" },
+    { url = "https://files.pythonhosted.org/packages/07/91/530cfa92b56287ac5e08d8d4e0db5be24f3ec2a05e67bb281bc0c69de37f/connected_components_3d-3.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:25ead6ff687cf465357014a0e034b4a96d7839afe6b7a80753e617f4923184ad", size = 519767, upload-time = "2026-05-05T05:18:49.193Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6b/7be5531ff5a6c0dd5303287487114ab0e4d0983b82cde91ae45cc6d918aa/connected_components_3d-3.28.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dd317321412652a0cea661ffb75624b1a3b76220a89911e4976a781adec396a8", size = 813952, upload-time = "2026-05-05T05:18:51.974Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/41/e13ec357c68d94fad25431d35ed48511922b7c5aea322a945d99005e1fd0/connected_components_3d-3.28.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2d51b4b40a54a70c89a07f9acc3029233702e06ffd8c4ed4acf020040622e276", size = 711468, upload-time = "2026-05-05T05:18:53.265Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/82/54518ff6f247116c1f3240275def170fefeccf7f302d831dd5106deb0b7a/connected_components_3d-3.28.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35e1b137c0783521457ddd8637bf0b0a7e7840eedbe5507ae68aa85fa34f7b35", size = 4311995, upload-time = "2026-05-05T05:18:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/2a/889a7e74ceef69ff9ddfda52779a4a379b9e3b141641ddb10a4003f01128/connected_components_3d-3.28.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef766190ca548938a815e772d78bc2bda4356ce39d0d885f6d05868168bcfc7f", size = 4649197, upload-time = "2026-05-05T05:18:57.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/df/3a7e6b70cde79cecb3218f6a1f02fda69b41b56510396f728a16c8668f5e/connected_components_3d-3.28.0-cp314-cp314-win32.whl", hash = "sha256:a2b3444fb0480030598acf195f82a101807e95e51a10594723205b1998a0b07e", size = 615448, upload-time = "2026-05-05T05:19:01.379Z" },
+    { url = "https://files.pythonhosted.org/packages/40/83/334b27b59e4d289e5b045b7494e2708efec41cc06b56415f2926d76c31c3/connected_components_3d-3.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:67be893926df66a75d7476aab8825330483f08673ec1d0bc50775e72f36d1c3b", size = 527969, upload-time = "2026-05-05T05:18:59.851Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f4/9f1fb4e9ef4b4605d5887fe2837633406ea504a635ccca61e47eaaec5618/connected_components_3d-3.28.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:79918ce3d34f81c37d1a66853aef69411ad61649149f6e698c1f1e765d5affc9", size = 834273, upload-time = "2026-05-05T05:19:02.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b3/f76e8c1debbbb7c60fb8b37378fa0d605793d86881eeac3aea0549d8d2a7/connected_components_3d-3.28.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2d656c07af7949c1794cfd6f4bf97705688b648e762c5d94b6e8947d95fb231e", size = 734122, upload-time = "2026-05-05T05:19:03.943Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f7/7cbddecefaf6660b4b710f12afdd62d58d6d72d0cf87667541a2011a67e6/connected_components_3d-3.28.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f69681203be1d78e95419a628e49c0ed21b25e856670dfca1e601c977d4737f1", size = 4340675, upload-time = "2026-05-05T05:19:06.288Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1f/a2689133e8bf0888a950700f63908394bd01081eeaec790161120a1caeaf/connected_components_3d-3.28.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e863d942e262273b42848d7582fd9c763aa040aa0824e085adc5aa00bbed176", size = 4600360, upload-time = "2026-05-05T05:19:08.777Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f3/fe7b3bd4f210d560be4241995f0cfa0ca5868673e82d7586d025d9f1affc/connected_components_3d-3.28.0-cp314-cp314t-win32.whl", hash = "sha256:ff6a02f9df509bd392064ddb0d3155084b34d028c5b2d3e1e31ecfa80dc7758c", size = 653401, upload-time = "2026-05-05T05:19:11.415Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7e/852b8e363d3d75ffdc32c60096ee7d98401154d5a4dbb5e83f1cb6e67c32/connected_components_3d-3.28.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a3fd1490388a9b09c7283a52f9e321ce8962d8a8f6d396a3d48e15ced7aafcf2", size = 579903, upload-time = "2026-05-05T05:19:10.184Z" },
+]
+
+[[package]]
 name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -786,6 +921,7 @@ dependencies = [
     { name = "membrain-seg" },
     { name = "monai" },
     { name = "mrcfile" },
+    { name = "nnunetv2" },
     { name = "numcodecs" },
     { name = "numpy" },
     { name = "pandas" },
@@ -794,6 +930,7 @@ dependencies = [
     { name = "scikit-image" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "simpleitk" },
     { name = "torch" },
     { name = "torch-cubic-spline-grids" },
     { name = "torchvision" },
@@ -834,6 +971,7 @@ requires-dist = [
     { name = "membrain-seg" },
     { name = "monai" },
     { name = "mrcfile" },
+    { name = "nnunetv2" },
     { name = "numcodecs", specifier = "<0.16.0" },
     { name = "numpy" },
     { name = "pandas", specifier = ">=2.2.3" },
@@ -846,6 +984,7 @@ requires-dist = [
     { name = "scikit-image" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
     { name = "scipy" },
+    { name = "simpleitk" },
     { name = "torch" },
     { name = "torch-cubic-spline-grids", specifier = ">=0.5.0" },
     { name = "torchvision", specifier = ">=0.21.0" },
@@ -1249,6 +1388,18 @@ wheels = [
 ]
 
 [[package]]
+name = "dynamic-network-architectures"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops" },
+    { name = "numpy" },
+    { name = "timm" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/26/d71666ae0bc736b39387171cb8e198ba100984bc399b383f5b26b6cfa233/dynamic_network_architectures-0.4.3.tar.gz", hash = "sha256:693194e6c99e0da7dfc693e740bd2a79880f0a70888d305d5702d8afeed1b680", size = 28291, upload-time = "2026-01-23T14:10:49.986Z" }
+
+[[package]]
 name = "dynamotable"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1498,6 +1649,15 @@ s3 = [
 ]
 
 [[package]]
+name = "future"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
+]
+
+[[package]]
 name = "gdown"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1544,6 +1704,15 @@ wheels = [
 ]
 
 [[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1581,6 +1750,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1609,6 +1810,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/a5/33b49ba7bea7c41bb37f74ec0f8beea0831e052330196633fe2c77516ea6/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8", size = 661479, upload-time = "2026-05-06T14:14:32.029Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1624,6 +1845,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "imagecodecs"
+version = "2026.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/8d/dc18623e5e926ad53c626e128c8baaf4ec42e41029cf0a07381cfef79289/imagecodecs-2026.3.6.tar.gz", hash = "sha256:471b8a4d1b3843cbf7179b45f7d7261f0c0b28809efc1ca6c47822477b143b85", size = 9565259, upload-time = "2026-03-07T01:26:41.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/db/873d063c99a726d772bf6f076288da59bb12e9f2af3518c2e4de5fde234d/imagecodecs-2026.3.6-cp311-abi3-macosx_10_15_x86_64.whl", hash = "sha256:44cfb3b609d941014f8ac7cf8611b15ccfd7119443bbb6b5e53916b242d31f9e", size = 13953250, upload-time = "2026-03-07T06:13:36.959Z" },
+    { url = "https://files.pythonhosted.org/packages/42/84/36c38a82f033ffbc9e706dad32be7148f130fc00e7bb417ab60e063897a0/imagecodecs-2026.3.6-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e64037f22980a211b17bf6bdf03f14ff459a7432eec24f7a58c342f6992132fa", size = 11697496, upload-time = "2026-03-07T01:25:56.412Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fa/f67c4e644fdf06503e120f9d1c8d8654b99066dea7093a674b67704fa4a4/imagecodecs-2026.3.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:30fa140bb1a112a889926af36977214ed52a22e4557356043259b5e2f79cfba5", size = 25604431, upload-time = "2026-03-07T01:26:00.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/93ea9cbab7f57b4e60480c51fc51d8e138e399d11797c981d5f6e79f9832/imagecodecs-2026.3.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e30a14aa2e1c6c90e00375292726486c1d90bf003b1414d608ea4d1f62fd8a79", size = 26468592, upload-time = "2026-03-07T01:26:04.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a7/e3a89b2c516eaca7446e8f1335daeec90764b50888af5e073a2b6a987fcf/imagecodecs-2026.3.6-cp311-abi3-win32.whl", hash = "sha256:c972a45dfee1befbac048ba3492607003e9a185811e8febdc1ed531d48c07e75", size = 15597722, upload-time = "2026-03-07T01:26:08.106Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c7/2b37a7fe9a2eb21011e50f046d62e68ac4e0f8d6ad94d7a10e9f8e8d685f/imagecodecs-2026.3.6-cp311-abi3-win_amd64.whl", hash = "sha256:e8fba5b9ac7be109ed35070208bc1683fa17cc381ed9535a4eae200c6d883bd8", size = 19177403, upload-time = "2026-03-07T01:26:11.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/94e930cef9e0a29a2df5e3ba3bacd2c2f1e34ca373fe48624b64af8ae91c/imagecodecs-2026.3.6-cp311-abi3-win_arm64.whl", hash = "sha256:fc4856913be6c8b3861223158920d934a0ae203149a435f585622dbbff8ed696", size = 15193605, upload-time = "2026-03-07T01:26:15.016Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/0b/ba7ca5a14cf2ff744c47898ab9e98b6b96b364bce1459afcab5f4e5ea2bb/imagecodecs-2026.3.6-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ea2cd774854a3bfe1dc9508f98907edc877c02a78642ab371adbdec65a8865cc", size = 14335958, upload-time = "2026-03-07T06:13:39.726Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d9/4750fb9739d474e399fa566b3a5c7033f2c9c0078bc869473b23d3e0d4b7/imagecodecs-2026.3.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6efa104ce600f61fef03a43daab34fe2953c8adb4e4ee6eb9544825f5361e5ab", size = 12021474, upload-time = "2026-03-07T01:26:18.008Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d3/f0a71c797f836021241500d4a459b0f93317f2b5c9bcc39fb1eaa50e01ea/imagecodecs-2026.3.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:16fd83dd25d9c888317bc8cbbc5d7490b78c84c58275d80fb71ea7b28645276a", size = 29606531, upload-time = "2026-03-07T01:26:22.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/a1b433418306636fc22a94b669d7ebbbde8e3b26aef7d693c08f9f8a65af/imagecodecs-2026.3.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:39fcf671537cc92dd24ba4dcba257d8aa47e6f58018e839a5216c626f03d4126", size = 30039276, upload-time = "2026-03-07T01:26:26.718Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/96/1474c0e242fb11d68304f858298971370fdfcecc404dbd9993a3ea449b4f/imagecodecs-2026.3.6-cp314-cp314t-win32.whl", hash = "sha256:65110ff30723a6e0b79c6c74ff52909a34b131366c4f76b1b68084cca5fcd982", size = 16345843, upload-time = "2026-03-07T01:26:30.498Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/13/d0e09d8aaafe6fac1aa1bd8c0dcc0f024998ea4a23477128db14a085b4cf/imagecodecs-2026.3.6-cp314-cp314t-win_amd64.whl", hash = "sha256:1b810efeeb06bdcca07ae410a81bdb5eb9fb38f91689baf0f0b75783f5119a40", size = 20230890, upload-time = "2026-03-07T01:26:33.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/06/3a5fe853e4df9a3655f8be81c1eb48013aab282c1557341b8634dd718e32/imagecodecs-2026.3.6-cp314-cp314t-win_arm64.whl", hash = "sha256:a2363c64e346cee4136f02a207b1b645729142f5260d122ddc3d5ff9e32ac6b1", size = 15911854, upload-time = "2026-03-07T01:26:38.072Z" },
 ]
 
 [[package]]
@@ -1644,11 +1890,20 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
 ]
 
 [[package]]
@@ -2223,6 +2478,15 @@ wheels = [
 ]
 
 [[package]]
+name = "linecache2"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/b0/963c352372c242f9e40db02bbc6a39ae51bde15dddee8523fe4aca94a97e/linecache2-1.0.0.tar.gz", hash = "sha256:4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c", size = 11013, upload-time = "2015-03-06T01:33:30.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/a3/c5da2a44c85bfbb6eebcfc1dde24933f8704441b98fdde6528f4831757a6/linecache2-1.0.0-py2.py3-none-any.whl", hash = "sha256:e78be9c0a0dfcbac712fe04fbf92b96cddae80b1b842f24248214c8496f006ef", size = 12967, upload-time = "2015-03-06T01:33:36.657Z" },
+]
+
+[[package]]
 name = "linkify-it-py"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2606,6 +2870,59 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/97/560d11202bcd537abca693fd85d81cebe2107ba17301de42b01ac1677b69/msgpack-1.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2e86a607e558d22985d856948c12a3fa7b42efad264dca8a3ebbcfa2735d786c", size = 82271, upload-time = "2025-10-08T09:14:49.967Z" },
+    { url = "https://files.pythonhosted.org/packages/83/04/28a41024ccbd67467380b6fb440ae916c1e4f25e2cd4c63abe6835ac566e/msgpack-1.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:283ae72fc89da59aa004ba147e8fc2f766647b1251500182fac0350d8af299c0", size = 84914, upload-time = "2025-10-08T09:14:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/b817349db6886d79e57a966346cf0902a426375aadc1e8e7a86a75e22f19/msgpack-1.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61c8aa3bd513d87c72ed0b37b53dd5c5a0f58f2ff9f26e1555d3bd7948fb7296", size = 416962, upload-time = "2025-10-08T09:14:51.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e0/6cc2e852837cd6086fe7d8406af4294e66827a60a4cf60b86575a4a65ca8/msgpack-1.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:454e29e186285d2ebe65be34629fa0e8605202c60fbc7c4c650ccd41870896ef", size = 426183, upload-time = "2025-10-08T09:14:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/6a19f030b3d2ea906696cedd1eb251708e50a5891d0978b012cb6107234c/msgpack-1.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7bc8813f88417599564fafa59fd6f95be417179f76b40325b500b3c98409757c", size = 411454, upload-time = "2025-10-08T09:14:54.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/cd/9098fcb6adb32187a70b7ecaabf6339da50553351558f37600e53a4a2a23/msgpack-1.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bafca952dc13907bdfdedfc6a5f579bf4f292bdd506fadb38389afa3ac5b208e", size = 422341, upload-time = "2025-10-08T09:14:56.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ae/270cecbcf36c1dc85ec086b33a51a4d7d08fc4f404bdbc15b582255d05ff/msgpack-1.1.2-cp311-cp311-win32.whl", hash = "sha256:602b6740e95ffc55bfb078172d279de3773d7b7db1f703b2f1323566b878b90e", size = 64747, upload-time = "2025-10-08T09:14:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/79/309d0e637f6f37e83c711f547308b91af02b72d2326ddd860b966080ef29/msgpack-1.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:d198d275222dc54244bf3327eb8cbe00307d220241d9cec4d306d49a44e85f68", size = 71633, upload-time = "2025-10-08T09:14:59.177Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4d/7c4e2b3d9b1106cd0aa6cb56cc57c6267f59fa8bfab7d91df5adc802c847/msgpack-1.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:86f8136dfa5c116365a8a651a7d7484b65b13339731dd6faebb9a0242151c406", size = 64755, upload-time = "2025-10-08T09:15:00.48Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2787,6 +3104,62 @@ wheels = [
 ]
 
 [[package]]
+name = "ndindex"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/92/4b9d2f4e0f3eabcfc7b02b48261f6e5ad36a3e2c1bbdcc4e3b7b6c768fa6/ndindex-1.10.1.tar.gz", hash = "sha256:0f6113c1f031248f8818cbee1aa92aa3c9472b7701debcce9fddebcd2f610f11", size = 271395, upload-time = "2025-11-19T20:40:08.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/d9/c94ab6151c9fdd199c2b560f23e3759a9fb86a7a1275855e0b97291bf05a/ndindex-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e2ad917bcdf8dc5ba1e21f01054c991d26862d4d01c3c203a50e907096d558ac", size = 172128, upload-time = "2025-11-19T20:38:28.977Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/34/880c4073750766e44492d51280d025f28e36475394ca3d741b0a4adad4b0/ndindex-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e851990a68937db5f485cd9f3e760c1fd47fa0f2a99f63a5e2cc880908faf3bb", size = 171423, upload-time = "2025-11-19T20:38:30.357Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/1e/0342da55dabe4075efc2b2ab91a6a22ed3047c5bd511ef771a7a3f822c90/ndindex-1.10.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27385939f317b55773ea53f6bf9334810cf1d66206034c0a6a6f2a88f2001c3c", size = 519590, upload-time = "2025-11-19T20:38:32.464Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cb/7a02b6f29b15a16cd0002f4591d14493eff8e9236f7ca4c02ee4d4bcefbd/ndindex-1.10.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fdf3ca16efcdfbb8800aa88fbab1bc6528e6a0504bcb9cf7af4cb9d50e9f5d9", size = 516676, upload-time = "2025-11-19T20:38:34.276Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d5/38da808f968a54b0fead2d7e15ca011d3df93c96a07f4914e8ef3974506e/ndindex-1.10.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3307817bdc92846b18f309fae3582856f567dd6e0742fb0b41ac68682bfc4e2a", size = 1491141, upload-time = "2025-11-19T20:38:35.785Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1f/8c66ef982a01ae4cbdabba679a2bc711f262cedf23bfb9682293146f8a98/ndindex-1.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae73cd2d66b09ef2f2a7d7f93bad396d6abf168d1ee825e403c6c5fb8ae1341c", size = 1543876, upload-time = "2025-11-19T20:38:37.456Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/7c7e3a3c6e81b4284fd0d53cbaec51d9e5b90df26dd78e9bde06cb307217/ndindex-1.10.1-cp311-cp311-win32.whl", hash = "sha256:890bb92f0a779e6f16bdbcc8bd2e06c32bcc0239e5893ba246114eb924aecaaa", size = 149149, upload-time = "2025-11-19T20:38:38.911Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/38/99e1fb0effdef74b883be615ea0053ebcea28a53fd8b896263f4e99b0113/ndindex-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:1827a40301405b44ad709e388c5b48cf35cd90a67f77e63f0f17d87f6000fa81", size = 157246, upload-time = "2025-11-19T20:38:40.197Z" },
+    { url = "https://files.pythonhosted.org/packages/65/90/774ddd08b2a1b41faa56da111f0fbfeb4f17ee537214c938ef41d61af949/ndindex-1.10.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:87f83e8c35a7f49a68cd3a3054c406e6c22f8c1315f3905f7a778c657669187e", size = 177348, upload-time = "2025-11-19T20:38:41.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ee/a423e857f5b45da3adc8ddbcfbfd4a0e9a047edce3915d3e3d6e189b6bd9/ndindex-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cf9e05986b2eb8c5993bce0f911d6cedd15bda30b5e35dd354b1ad1f4cc3599d", size = 176561, upload-time = "2025-11-19T20:38:43.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/40/139b6b050ba2b2a0bb40e0381a352b1eb6551302dcb8f86fb4c97dd34e92/ndindex-1.10.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:046c1e88d46b2bd2fd3483e06d27b4e85132b55bc693f2fca2db0bb56eea1e78", size = 542901, upload-time = "2025-11-19T20:38:44.43Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ae/defd665dbbeb2fffa077491365ed160acaec49274ce8d4b979f55db71f18/ndindex-1.10.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03cf1e6cdac876bd8fc92d3b65bb223496b1581d10eab3ba113f7c195121a959", size = 546875, upload-time = "2025-11-19T20:38:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/59/43/6d54d48e8eaee25cdab70d3e4c4f579ddb0255e4f1660040d5ad55e029c6/ndindex-1.10.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:752e78a5e87911ded117c57a7246596f26c9c6da066de3c2b533b3db694949bb", size = 1510036, upload-time = "2025-11-19T20:38:47.444Z" },
+    { url = "https://files.pythonhosted.org/packages/09/61/e28ba3b98eacd18193176526526b34d7d70d2a6f9fd2b4d8309ab5692678/ndindex-1.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c9dd58d91220b1c1fe516324bfcf4114566c98e84b1cbbe416abe345c75bd557", size = 1571849, upload-time = "2025-11-19T20:38:48.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/63/83fff78a3712cb9f478dd84a19ec389acf6f8c7b01dc347a65ae74e6123d/ndindex-1.10.1-cp312-cp312-win32.whl", hash = "sha256:3b0d9ce2c8488444499ab6d40e92e09867bf4413f5cf04c01635de923f44aa67", size = 149792, upload-time = "2025-11-19T20:38:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/52/fd/a5e3c8c043d0dddea6cd4567bfaea568f022ac197301882b3d85d9c1e9b3/ndindex-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c026dbbf2455d97ce6456d8a50b349aee8fefa11027d020638c89e9be2c9c4c", size = 158164, upload-time = "2025-11-19T20:38:52.242Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ea/03676266cb38cc671679a9d258cc59bfc58c69726db87b0d6eeafb308895/ndindex-1.10.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:157b5c34a1b779f5d27b790d9bd7e7b156d284e76be83c591a3ba003984f4956", size = 176323, upload-time = "2025-11-19T20:38:53.528Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f4/2d350439031b108b0bb8897cad315390c5ad88c14d87419a54c2ffa95c80/ndindex-1.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f99b3e89220da3244d03c9c5473669c7107d361c129fd9b064622744dee1ce15", size = 175584, upload-time = "2025-11-19T20:38:57.968Z" },
+    { url = "https://files.pythonhosted.org/packages/77/34/a51b7c6f7159718a6a0a694fc1058b94d793c416d9a4fd649f1924cce5f8/ndindex-1.10.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6928e47fb008903f2e41309b7ff1e59b16abbcd59e2e945454571c28b2433c9e", size = 524127, upload-time = "2025-11-19T20:38:59.412Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/d8f19f0b8fc9c5585b50fda44c05415da0bdc5fa9c9c69011015dac27880/ndindex-1.10.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69a2cb1ac7be955c3c77f1def83f410775a81525c9ce2d4c0a3f2a61589ed47", size = 528213, upload-time = "2025-11-19T20:39:00.882Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a9/77d9d037e871a3faa8579b354ca2dd09cc5bbf3e085d9e3c67f786d55ee3/ndindex-1.10.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cb76e0f3f235d8b1c768b17e771de48775d281713795c3aa045e8114ad61bdda", size = 1492172, upload-time = "2025-11-19T20:39:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/29/ad13676fc9312e0aa1a80a7c04bcb0b502b877ed4956136117ad663eced0/ndindex-1.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7da34a78410c14341d5fff73be5ce924bd36500bf7f640fc59b8607d3a0df95e", size = 1552614, upload-time = "2025-11-19T20:39:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/e6e6fd81423810c07ae623c4d36e099f42a812994977e8e3bfa182c02472/ndindex-1.10.1-cp313-cp313-win32.whl", hash = "sha256:9599fcb7411ffe601c367f0a5d4bc0ed588e3e7d9dc7604bdb32c8f669456b9e", size = 149330, upload-time = "2025-11-19T20:39:05.727Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d3/830a20626e2ec0e31a926be90e67068a029930f99e6cfebf2f9768e7b7b1/ndindex-1.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:ef3ef22390a892d16286505083ee5b326317b21c255a0c7f744b1290a0b964a6", size = 157309, upload-time = "2025-11-19T20:39:07.394Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/73/3bdeecd1f6ec0ad81478a53d96da4ba9be74ed297c95f2b4fbe2b80843e1/ndindex-1.10.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:72af787dcee3661f36fff9d144d989aacefe32e2c8b51ceef9babd46afb93a18", size = 181022, upload-time = "2025-11-19T20:39:10.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b1/0d97ba134b5aa71b5ed638fac193a7ec4d987e091e2f4e4162ebdaacbda1/ndindex-1.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa60637dfae1ee3fc057e420a52cc4ace38cf2c0d1a0451af2a3cba84d281842", size = 181289, upload-time = "2025-11-19T20:39:11.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d7/1df02df24880ce3f3c8137b6f3ca5a901a58d9079dcfd8c818419277ff87/ndindex-1.10.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d0ebdba2fade3f6916fe21fd49e2a0935af4f58c56100a60f3f2eb26e20baee7", size = 632517, upload-time = "2025-11-19T20:39:13.259Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/b509c2b14e9b10710fe6ab6ba8bda1ee6ce36ab16397ff2f5bbb33bbbba3/ndindex-1.10.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:346a4bf09f5771548665c8206e81daadb6b9925d409746e709894bdd98adc701", size = 616179, upload-time = "2025-11-19T20:39:14.757Z" },
+    { url = "https://files.pythonhosted.org/packages/38/e3/f89d60cf351c33a484bf1a4546a5dee6f4e7a6a973613ffa12bd316b14ad/ndindex-1.10.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:23d35696f802548143b5cc199bf2f171efb0061aa7934959251dd3bae56d038c", size = 1588373, upload-time = "2025-11-19T20:39:16.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/19/002fc1e6a4abeef8d92e9aa2e43aea4d462f6b170090f7752ea8887f4897/ndindex-1.10.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a91e1a0398120233d5c3b23ccb2d4b78e970d66136f1a7221fa9a53873c3d5c5", size = 1636436, upload-time = "2025-11-19T20:39:18.266Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/28b1ad78c787ac8fafd6e26419a80366617784b1779e3857fa687492f6bc/ndindex-1.10.1-cp313-cp313t-win32.whl", hash = "sha256:78bfe25941d2dac406391ddd9baf0b0fce163807b98ecc2c47a3030ee8466319", size = 158780, upload-time = "2025-11-19T20:39:20.454Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/56/b81060607a19865bb8be8d705b1b3e8aefb8747c0fbd383e38b4cae4bd71/ndindex-1.10.1-cp313-cp313t-win_amd64.whl", hash = "sha256:08bfdc1f7a0b408d15b3ce61d141ebbebdb47a25341967e425e104c5bd512a5c", size = 167485, upload-time = "2025-11-19T20:39:21.733Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/aac1131e9f3a5635ba7b0312c3bfa610511ab4108f85c0d914a32887aa00/ndindex-1.10.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9b5297f207ebc068c7cdf9e3cd7b95aa5c9ec04295d0a7e56b529f66787d4685", size = 176478, upload-time = "2025-11-19T20:39:23.747Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/05/a0d8ca0432c84550bc17af6d6479a803936895b8b8403a1216c5a55475fb/ndindex-1.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c5e9762452b163e33cfb6e821f86e45ba0b53bdfcd23ab5d57b48a8f566898cb", size = 175480, upload-time = "2025-11-19T20:39:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/09/4a/028ab78a9f29fd2a7e86a90337cde4658eaa77b425c63045d83a1d2e4f26/ndindex-1.10.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf80241b40adffdc3276b2c9fb63a96c6c98b4a9d941892738de8add65083962", size = 528125, upload-time = "2025-11-19T20:39:26.798Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a9/bd823b345fb06c83ade6ef1c1933521d4357cd04490e684d4fa30126926c/ndindex-1.10.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf5855881884b8467dfcf45764ccf2e4279075be14b155b89c96994bb08d2e6f", size = 527328, upload-time = "2025-11-19T20:39:28.292Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/40b9c15588cbf9dde43c4fb88a31dd1f636a913fa29649f18f8e3ebca36a/ndindex-1.10.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e81a9bd36fe054b6c9fcc53d26bc9a28cf15d1ab52a0f5b854f894116f3a54e1", size = 1497508, upload-time = "2025-11-19T20:39:30.735Z" },
+    { url = "https://files.pythonhosted.org/packages/24/8f/b8048f7837d2e9dff0af507b398307fa84a2aa9ea3db71b4aa800b21da4a/ndindex-1.10.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:588e8875d836a93b3cd9af482c8074bb02288ae1aff92cf277e1f02d9ae0f992", size = 1552625, upload-time = "2025-11-19T20:39:32.404Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/0ecb53c7e690a44769f2f92a843723ccb1d0ce080d93ba1ea811304cca12/ndindex-1.10.1-cp314-cp314-win32.whl", hash = "sha256:28741daca5926adff402247cd406f453ed5bb6042e82d6855938f805190e5ce9", size = 151237, upload-time = "2025-11-19T20:39:34.847Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/4e/197982fa8b4e6e6b9d15c38505c41076d1c552921f09f4d35acbbbbc0b70/ndindex-1.10.1-cp314-cp314-win_amd64.whl", hash = "sha256:59a3222befc0f7cdc85fb9b90a567ae890f70a864bdeb660517e9ebcb36bf1bc", size = 158925, upload-time = "2025-11-19T20:39:37.149Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ad/116b6154046a69fc04e2d4490905801d3839a3f21290c0b4d49b1044e251/ndindex-1.10.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967b87b88dadb62555ec1039695c347254eccb8ca3d124c0e5dbe084c525fa93", size = 181724, upload-time = "2025-11-19T20:39:38.635Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/00/3ce4351366c890bcc87a5e9f1f90102547962eef356ac7c799bfdd0dddce/ndindex-1.10.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c67dde588c0fb89d872931a4ed5f9b4d21c1c70a3d92fdf0812a1de154239816", size = 181653, upload-time = "2025-11-19T20:39:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/05/a6fda696a2f02a3f8dd2ee9d816cb2edff6423bf0110a4876cc3b1259732/ndindex-1.10.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c65ca639a7abf72d79f22424f4abd18dece1f289a2b7b028a0ca455edd2168d4", size = 630898, upload-time = "2025-11-19T20:39:41.495Z" },
+    { url = "https://files.pythonhosted.org/packages/73/78/eb2e5d067d4c054451e33eaece74cbdcb58236dc60516e73d783dae34c7e/ndindex-1.10.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c3634a8df43e7928122225a3d64d850c8957bd1edf2e403907deacb478af27b", size = 614419, upload-time = "2025-11-19T20:39:43.254Z" },
+    { url = "https://files.pythonhosted.org/packages/78/51/261bfb49eb7920c2a7314cacba5821930a529911dce48c7c6cd786096a5a/ndindex-1.10.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9d581f931e61f182478f18bdf5edd3955899df5da4892ed0d5de547a4cfd5b6f", size = 1587517, upload-time = "2025-11-19T20:39:44.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/37/084a332ecdf8b0049151bd78001a7baf2daf7f500d043beb8a1f95d0f4e3/ndindex-1.10.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:78ce45106ebf67aeba99714818c721d8fd5fb9534daebd2565665a2d64b50fc9", size = 1635372, upload-time = "2025-11-19T20:39:47.231Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f4/716580fbb03018ab1daa86ed12c1925c67e79689db5fee82393e840758a2/ndindex-1.10.1-cp314-cp314t-win32.whl", hash = "sha256:fe5341e24dc992b09c258456ac90a09a6d25efdc2cb86dcc91d32c8891e1df9a", size = 162186, upload-time = "2025-11-19T20:39:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/20/28f669c09a470e7f523b0cc10b94336664d9648594015e3f2a1ec29047b1/ndindex-1.10.1-cp314-cp314t-win_amd64.whl", hash = "sha256:37f87f0e7690ae0324334740e0661d6297f2e62c9bf925127d249fb7eddd0ad8", size = 171077, upload-time = "2025-11-19T20:39:50.108Z" },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2803,6 +3176,52 @@ sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
+
+[[package]]
+name = "nibabel"
+version = "5.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-resources", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/01/3d2cc510c616bc8e27be17a063070d9126f69407961594a9ae734ea51121/nibabel-5.4.2.tar.gz", hash = "sha256:d5f4b9076a13178ae7f7acf18c8dbd503ee1c4d5c0c23b85df7be87efcbb49da", size = 4663132, upload-time = "2026-03-11T13:31:52.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/d7/601b6396b33536811668935faa790112266c70661be94555999be431f86f/nibabel-5.4.2-py3-none-any.whl", hash = "sha256:553482c5f1e1034fc312edf6fb7f32236c0056439845d1c29293b7e8c98d4854", size = 3300985, upload-time = "2026-03-11T13:31:50.028Z" },
+]
+
+[[package]]
+name = "nnunetv2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "acvl-utils" },
+    { name = "batchgenerators" },
+    { name = "batchgeneratorsv2" },
+    { name = "blosc2" },
+    { name = "dynamic-network-architectures" },
+    { name = "einops" },
+    { name = "graphviz" },
+    { name = "imagecodecs" },
+    { name = "matplotlib" },
+    { name = "nibabel" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "requests" },
+    { name = "scikit-image" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "seaborn" },
+    { name = "simpleitk" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "tifffile", version = "2026.4.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "yacs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/89/f9faa8bb35ba43b4d84017e52bc0099ac7a0d2c3c3ef168e2c46faebd1a1/nnunetv2-2.7.0.tar.gz", hash = "sha256:cf905de25489a409b3f3f8c0cc07f179cd965dddc092127b67c07d3e03edc401", size = 205601, upload-time = "2026-04-09T12:36:48.693Z" }
 
 [[package]]
 name = "nodeenv"
@@ -2863,6 +3282,65 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/56/9863fa6dc679f40a31bea5e9713ee5507a31dcd3ee82ea4b1a9268ce52e8/numcodecs-0.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1d471a1829ce52d3f365053a2bd1379e32e369517557c4027ddf5ac0d99c591e", size = 1180294, upload-time = "2025-02-10T10:23:25.533Z" },
     { url = "https://files.pythonhosted.org/packages/fa/91/d96999b41e3146b6c0ce6bddc5ad85803cb4d743c95394562c2a4bb8cded/numcodecs-0.15.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dfdea4a67108205edfce99c1cb6cd621343bc7abb7e16a041c966776920e7de", size = 8834323, upload-time = "2025-02-10T10:23:27.46Z" },
     { url = "https://files.pythonhosted.org/packages/c3/32/233e5ede6568bdb044e6f99aaa9fa39827ff3109c6487fc137315f733586/numcodecs-0.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:a4f7bdb26f1b34423cb56d48e75821223be38040907c9b5954eeb7463e7eb03c", size = 831955, upload-time = "2025-02-10T10:23:30.601Z" },
+]
+
+[[package]]
+name = "numexpr"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2f/fdba158c9dbe5caca9c3eca3eaffffb251f2fb8674bf8e2d0aed5f38d319/numexpr-2.14.1.tar.gz", hash = "sha256:4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b", size = 119400, upload-time = "2025-10-13T16:17:27.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/67999bdd1ed1f938d38f3fedd4969632f2f197b090e50505f7cc1fa82510/numexpr-2.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2d03fcb4644a12f70a14d74006f72662824da5b6128bf1bcd10cc3ed80e64c34", size = 163195, upload-time = "2025-10-13T16:16:31.212Z" },
+    { url = "https://files.pythonhosted.org/packages/25/95/d64f680ea1fc56d165457287e0851d6708800f9fcea346fc1b9957942ee6/numexpr-2.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2773ee1133f77009a1fc2f34fe236f3d9823779f5f75450e183137d49f00499f", size = 152088, upload-time = "2025-10-13T16:16:33.186Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7f/3bae417cb13ae08afd86d08bb0301c32440fe0cae4e6262b530e0819aeda/numexpr-2.14.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ebe4980f9494b9f94d10d2e526edc29e72516698d3bf95670ba79415492212a4", size = 451126, upload-time = "2025-10-13T16:13:22.248Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/1a/edbe839109518364ac0bd9e918cf874c755bb2c128040e920f198c494263/numexpr-2.14.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a381e5e919a745c9503bcefffc1c7f98c972c04ec58fc8e999ed1a929e01ba6", size = 442012, upload-time = "2025-10-13T16:14:51.416Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b1/be4ce99bff769a5003baddac103f34681997b31d4640d5a75c0e8ed59c78/numexpr-2.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d08856cfc1b440eb1caaa60515235369654321995dd68eb9377577392020f6cb", size = 1415975, upload-time = "2025-10-13T16:13:26.088Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/33/b33b8fdc032a05d9ebb44a51bfcd4b92c178a2572cd3e6c1b03d8a4b45b2/numexpr-2.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03130afa04edf83a7b590d207444f05a00363c9b9ea5d81c0f53b1ea13fad55a", size = 1464683, upload-time = "2025-10-13T16:14:58.87Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b2/ddcf0ac6cf0a1d605e5aecd4281507fd79a9628a67896795ab2e975de5df/numexpr-2.14.1-cp311-cp311-win32.whl", hash = "sha256:db78fa0c9fcbaded3ae7453faf060bd7a18b0dc10299d7fcd02d9362be1213ed", size = 166838, upload-time = "2025-10-13T16:17:06.765Z" },
+    { url = "https://files.pythonhosted.org/packages/64/72/4ca9bd97b2eb6dce9f5e70a3b6acec1a93e1fb9b079cb4cba2cdfbbf295d/numexpr-2.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:e9b2f957798c67a2428be96b04bce85439bed05efe78eb78e4c2ca43737578e7", size = 160069, upload-time = "2025-10-13T16:17:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/c473fc04a371f5e2f8c5749e04505c13e7a8ede27c09e9f099b2ad6f43d6/numexpr-2.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:91ebae0ab18c799b0e6b8c5a8d11e1fa3848eb4011271d99848b297468a39430", size = 162790, upload-time = "2025-10-13T16:16:34.903Z" },
+    { url = "https://files.pythonhosted.org/packages/45/93/b6760dd1904c2a498e5f43d1bb436f59383c3ddea3815f1461dfaa259373/numexpr-2.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47041f2f7b9e69498fb311af672ba914a60e6e6d804011caacb17d66f639e659", size = 152196, upload-time = "2025-10-13T16:16:36.593Z" },
+    { url = "https://files.pythonhosted.org/packages/72/94/cc921e35593b820521e464cbbeaf8212bbdb07f16dc79fe283168df38195/numexpr-2.14.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d686dfb2c1382d9e6e0ee0b7647f943c1886dba3adbf606c625479f35f1956c1", size = 452468, upload-time = "2025-10-13T16:13:29.531Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/43/560e9ba23c02c904b5934496486d061bcb14cd3ebba2e3cf0e2dccb6c22b/numexpr-2.14.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee6d4fbbbc368e6cdd0772734d6249128d957b3b8ad47a100789009f4de7083", size = 443631, upload-time = "2025-10-13T16:15:02.473Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/6c/78f83b6219f61c2c22d71ab6e6c2d4e5d7381334c6c29b77204e59edb039/numexpr-2.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3a2839efa25f3c8d4133252ea7342d8f81226c7c4dda81f97a57e090b9d87a48", size = 1417670, upload-time = "2025-10-13T16:13:33.464Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/bb/1ccc9dcaf46281568ce769888bf16294c40e98a5158e4b16c241de31d0d3/numexpr-2.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9f9137f1351b310436662b5dc6f4082a245efa8950c3b0d9008028df92fefb9b", size = 1466212, upload-time = "2025-10-13T16:15:12.828Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9f/203d82b9e39dadd91d64bca55b3c8ca432e981b822468dcef41a4418626b/numexpr-2.14.1-cp312-cp312-win32.whl", hash = "sha256:36f8d5c1bd1355df93b43d766790f9046cccfc1e32b7c6163f75bcde682cda07", size = 166996, upload-time = "2025-10-13T16:17:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/ffe750b5452eb66de788c34e7d21ec6d886abb4d7c43ad1dc88ceb3d998f/numexpr-2.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:fdd886f4b7dbaf167633ee396478f0d0aa58ea2f9e7ccc3c6431019623e8d68f", size = 160187, upload-time = "2025-10-13T16:17:11.974Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b4/9f6d637fd79df42be1be29ee7ba1f050fab63b7182cb922a0e08adc12320/numexpr-2.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:09078ba73cffe94745abfbcc2d81ab8b4b4e9d7bfbbde6cac2ee5dbf38eee222", size = 162794, upload-time = "2025-10-13T16:16:38.291Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ae/d58558d8043de0c49f385ea2fa789e3cfe4d436c96be80200c5292f45f15/numexpr-2.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dce0b5a0447baa7b44bc218ec2d7dcd175b8eee6083605293349c0c1d9b82fb6", size = 152203, upload-time = "2025-10-13T16:16:39.907Z" },
+    { url = "https://files.pythonhosted.org/packages/13/65/72b065f9c75baf8f474fd5d2b768350935989d4917db1c6c75b866d4067c/numexpr-2.14.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06855053de7a3a8425429bd996e8ae3c50b57637ad3e757e0fa0602a7874be30", size = 455860, upload-time = "2025-10-13T16:13:35.811Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f9/c9457652dfe28e2eb898372da2fe786c6db81af9540c0f853ee04a0699cc/numexpr-2.14.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f9366d23a2e991fd5a8b5e61a17558f028ba86158a4552f8f239b005cdf83c", size = 446574, upload-time = "2025-10-13T16:15:17.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/99/8d3879c4d67d3db5560cf2de65ce1778b80b75f6fa415eb5c3e7bd37ba27/numexpr-2.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c5f1b1605695778896534dfc6e130d54a65cd52be7ed2cd0cfee3981fd676bf5", size = 1417306, upload-time = "2025-10-13T16:13:42.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/05/6bddac9f18598ba94281e27a6943093f7d0976544b0cb5d92272c64719bd/numexpr-2.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a4ba71db47ea99c659d88ee6233fa77b6dc83392f1d324e0c90ddf617ae3f421", size = 1466145, upload-time = "2025-10-13T16:15:27.464Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5d/cbeb67aca0c5a76ead13df7e8bd8dd5e0d49145f90da697ba1d9f07005b0/numexpr-2.14.1-cp313-cp313-win32.whl", hash = "sha256:638dce8320f4a1483d5ca4fda69f60a70ed7e66be6e68bc23fb9f1a6b78a9e3b", size = 166996, upload-time = "2025-10-13T16:17:13.803Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/23/9281bceaeb282cead95f0aa5f7f222ffc895670ea689cc1398355f6e3001/numexpr-2.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fdcd4735121658a313f878fd31136d1bfc6a5b913219e7274e9fca9f8dac3bb", size = 160189, upload-time = "2025-10-13T16:17:15.417Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/76/7aac965fd93a56803cbe502aee2adcad667253ae34b0badf6c5af7908b6c/numexpr-2.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:557887ad7f5d3c2a40fd7310e50597045a68e66b20a77b3f44d7bc7608523b4b", size = 163524, upload-time = "2025-10-13T16:16:42.213Z" },
+    { url = "https://files.pythonhosted.org/packages/58/65/79d592d5e63fbfab3b59a60c386853d9186a44a3fa3c87ba26bdc25b6195/numexpr-2.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:af111c8fe6fc55d15e4c7cab11920fc50740d913636d486545b080192cd0ad73", size = 152919, upload-time = "2025-10-13T16:16:44.229Z" },
+    { url = "https://files.pythonhosted.org/packages/84/78/3c8335f713d4aeb99fa758d7c62f0be1482d4947ce5b508e2052bb7aeee9/numexpr-2.14.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33265294376e7e2ae4d264d75b798a915d2acf37b9dd2b9405e8b04f84d05cfc", size = 465972, upload-time = "2025-10-13T16:13:45.061Z" },
+    { url = "https://files.pythonhosted.org/packages/35/81/9ee5f69b811e8f18746c12d6f71848617684edd3161927f95eee7a305631/numexpr-2.14.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83647d846d3eeeb9a9255311236135286728b398d0d41d35dedb532dca807fe9", size = 456953, upload-time = "2025-10-13T16:15:31.186Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/9b8bc6e294d85cbb54a634e47b833e9f3276a8bdf7ce92aa808718a0212d/numexpr-2.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6e575fd3ad41ddf3355d0c7ef6bd0168619dc1779a98fe46693cad5e95d25e6e", size = 1426199, upload-time = "2025-10-13T16:13:48.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ce/0d4fcd31ab49319740d934fba1734d7dad13aa485532ca754e555ca16c8b/numexpr-2.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:67ea4771029ce818573b1998f5ca416bd255156feea017841b86176a938f7d19", size = 1474214, upload-time = "2025-10-13T16:15:38.893Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/b2a93cbdb3ba4e009728ad1b9ef1550e2655ea2c86958ebaf03b9615f275/numexpr-2.14.1-cp313-cp313t-win32.whl", hash = "sha256:15015d47d3d1487072d58c0e7682ef2eb608321e14099c39d52e2dd689483611", size = 167676, upload-time = "2025-10-13T16:17:17.351Z" },
+    { url = "https://files.pythonhosted.org/packages/86/99/ee3accc589ed032eea68e12172515ed96a5568534c213ad109e1f4411df1/numexpr-2.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:94c711f6d8f17dfb4606842b403699603aa591ab9f6bf23038b488ea9cfb0f09", size = 161096, upload-time = "2025-10-13T16:17:19.174Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/36/9db78dfbfdfa1f8bf0872993f1a334cdd8fca5a5b6567e47dcb128bcb7c2/numexpr-2.14.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ede79f7ff06629f599081de644546ce7324f1581c09b0ac174da88a470d39c21", size = 162848, upload-time = "2025-10-13T16:16:46.216Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c1/a5c78ae637402c5550e2e0ba175275d2515d432ec28af0cdc23c9b476e65/numexpr-2.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2eac7a5a2f70b3768c67056445d1ceb4ecd9b853c8eda9563823b551aeaa5082", size = 152270, upload-time = "2025-10-13T16:16:47.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ed/aabd8678077848dd9a751c5558c2057839f5a09e2a176d8dfcd0850ee00e/numexpr-2.14.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5aedf38d4c0c19d3cecfe0334c3f4099fb496f54c146223d30fa930084bc8574", size = 455918, upload-time = "2025-10-13T16:13:50.338Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e1/3db65117f02cdefb0e5e4c440daf1c30beb45051b7f47aded25b7f4f2f34/numexpr-2.14.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439ec4d57b853792ebe5456e3160312281c3a7071ecac5532ded3278ede614de", size = 446512, upload-time = "2025-10-13T16:15:42.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/fb/7ceb9ee55b5f67e4a3e4d73d5af4c7e37e3c9f37f54bee90361b64b17e3f/numexpr-2.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e23b87f744e04e302d82ac5e2189ae20a533566aec76a46885376e20b0645bf8", size = 1417845, upload-time = "2025-10-13T16:13:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9b5764d0eafbbb2889288f80de773791358acf6fad1a55767538d8b79599/numexpr-2.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:44f84e0e5af219dbb62a081606156420815890e041b87252fbcea5df55214c4c", size = 1466211, upload-time = "2025-10-13T16:15:48.985Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/21/204db708eccd71aa8bc55bcad55bc0fc6c5a4e01ad78e14ee5714a749386/numexpr-2.14.1-cp314-cp314-win32.whl", hash = "sha256:1f1a5e817c534539351aa75d26088e9e1e0ef1b3a6ab484047618a652ccc4fc3", size = 168835, upload-time = "2025-10-13T16:17:20.82Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3e/d83e9401a1c3449a124f7d4b3fb44084798e0d30f7c11e60712d9b94cf11/numexpr-2.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:587c41509bc373dfb1fe6086ba55a73147297247bedb6d588cda69169fc412f2", size = 162608, upload-time = "2025-10-13T16:17:22.228Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d6/ec947806bb57836d6379a8c8a253c2aeaa602b12fef2336bfd2462bb4ed5/numexpr-2.14.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ec368819502b64f190c3f71be14a304780b5935c42aae5bf22c27cc2cbba70b5", size = 163525, upload-time = "2025-10-13T16:16:50.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/77/048f30dcf661a3d52963a88c29b52b6d5ce996d38e9313a56a922451c1e0/numexpr-2.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e87f6d203ac57239de32261c941e9748f9309cbc0da6295eabd0c438b920d3a", size = 152917, upload-time = "2025-10-13T16:16:52.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d3/956a13e628d722d649fbf2fded615134a308c082e122a48bad0e90a99ce9/numexpr-2.14.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd72d8c2a165fe45ea7650b16eb8cc1792a94a722022006bb97c86fe51fd2091", size = 466242, upload-time = "2025-10-13T16:13:55.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/dd/abe848678d82486940892f2cacf39e82eec790e8930d4d713d3f9191063b/numexpr-2.14.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70d80fcb418a54ca208e9a38e58ddc425c07f66485176b261d9a67c7f2864f73", size = 457149, upload-time = "2025-10-13T16:15:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/bb/797b583b5fb9da5700a5708ca6eb4f889c94d81abb28de4d642c0f4b3258/numexpr-2.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:edea2f20c2040df8b54ee8ca8ebda63de9545b2112872466118e9df4d0ae99f3", size = 1426493, upload-time = "2025-10-13T16:13:59.244Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c4/0519ab028fdc35e3e7ee700def7f2b4631b175cd9e1202bd7966c1695c33/numexpr-2.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:790447be6879a6c51b9545f79612d24c9ea0a41d537a84e15e6a8ddef0b6268e", size = 1474413, upload-time = "2025-10-13T16:15:59.211Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/33044878c8f4a75213cfe9c11d4c02058bb710a7a063fe14f362e8de1077/numexpr-2.14.1-cp314-cp314t-win32.whl", hash = "sha256:538961096c2300ea44240209181e31fae82759d26b51713b589332b9f2a4117e", size = 169502, upload-time = "2025-10-13T16:17:23.829Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/5a1a2c72528b429337f49911b18c302ecd36eeab00f409147e1aa4ae4519/numexpr-2.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a40b350cd45b4446076fa11843fa32bbe07024747aeddf6d467290bf9011b392", size = 163589, upload-time = "2025-10-13T16:17:25.696Z" },
 ]
 
 [[package]]
@@ -4262,6 +4740,28 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+]
+
+[[package]]
 name = "scikit-image"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4447,6 +4947,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "seaborn"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
 ]
 
 [[package]]
@@ -4718,6 +5232,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4a/e687f5957fead200faad58dbf9c9431a2bbb118040e96f5fb8a55f7ebc50/tifffile-2026.4.11.tar.gz", hash = "sha256:17758ff0c0d4db385792a083ad3ca51fcb0f4d942642f4d8f8bc1287fdcf17bc", size = 394956, upload-time = "2026-04-12T01:57:28.793Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/9f/74f110b4271ded519c7add4341cbabc824de26817ff1c345b3109df9e99c/tifffile-2026.4.11-py3-none-any.whl", hash = "sha256:9b94ffeddb39e97601af646345e8808f885773de01b299e480ed6d3a41509ec9", size = 248227, upload-time = "2026-04-12T01:57:26.969Z" },
+]
+
+[[package]]
+name = "timm"
+version = "1.0.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/9d/e4670765d1c033f97096c760b3b907eeb659cf80f3678640e5f060b04c6c/timm-1.0.22.tar.gz", hash = "sha256:14fd74bcc17db3856b1a47d26fb305576c98579ab9d02b36714a5e6b25cde422", size = 2382998, upload-time = "2025-11-05T04:06:09.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/14/fc04d491527b774ec7479897f5861959209de1480e4c4cd32ed098ff8bea/timm-1.0.22-py3-none-any.whl", hash = "sha256:888981753e65cbaacfc07494370138b1700a27b1f0af587f4f9b47bc024161d0", size = 2530238, upload-time = "2025-11-05T04:06:06.823Z" },
 ]
 
 [[package]]
@@ -5005,6 +5535,18 @@ wheels = [
 ]
 
 [[package]]
+name = "traceback2"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "linecache2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/7f/e20ba11390bdfc55117c8c6070838ec914e6f0053a602390a598057884eb/traceback2-1.4.0.tar.gz", hash = "sha256:05acc67a09980c2ecfedd3423f7ae0104839eccb55fc645773e1caa0951c3030", size = 15872, upload-time = "2015-03-09T06:57:27.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/0a/6ac05a3723017a967193456a2efa0aa9ac4b51456891af1e2353bb9de21e/traceback2-1.4.0-py2.py3-none-any.whl", hash = "sha256:8253cebec4b19094d67cc5ed5af99bf1dba1285292226e98a31929f87a5d6b23", size = 16793, upload-time = "2015-03-09T06:57:35.15Z" },
+]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5105,6 +5647,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]
+
+[[package]]
+name = "unittest2"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argparse" },
+    { name = "six" },
+    { name = "traceback2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/c4/2b0e2d185d9d60772c10350d9853646832609d2f299a8300ab730f199db4/unittest2-1.1.0.tar.gz", hash = "sha256:22882a0e418c284e1f718a822b3b022944d53d2d908e1690b319a9d3eb2c0579", size = 81432, upload-time = "2015-06-30T06:48:27.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/20/7f0f433060a962200b7272b8c12ba90ef5b903e218174301d0abfd523813/unittest2-1.1.0-py2.py3-none-any.whl", hash = "sha256:13f77d0875db6d9b435e1d4f41e74ad4cc2eb6e1d5c824996092b3430f088bb8", size = 96379, upload-time = "2015-06-30T06:48:35.477Z" },
 ]
 
 [[package]]
@@ -5296,6 +5852,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "yacs"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/3e/4a45cb0738da6565f134c01d82ba291c746551b5bc82e781ec876eb20909/yacs-0.1.8.tar.gz", hash = "sha256:efc4c732942b3103bea904ee89af98bcd27d01f0ac12d8d4d369f1e7a2914384", size = 11100, upload-time = "2020-08-10T16:37:47.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/4f/fe9a4d472aa867878ce3bb7efb16654c5d63672b86dc0e6e953a67018433/yacs-0.1.8-py3-none-any.whl", hash = "sha256:99f893e30497a4b66842821bac316386f7bd5c4f47ad35c9073ef089aa33af32", size = 14747, upload-time = "2020-08-10T16:37:46.4Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a full nnUNet training and inference pipeline accessible via the copick-torch CLI. The workflow covers three stages — dataset preparation, model training, and inference — each exposed as a 
  CLI subcommand and registered as a copick entry point.                                                                                                                                            
                  
  What's new                                                                                                                                                                                        
                  
  copick_torch/nnunet/ module                                                                                                                                                                       
   
  - prepare (`copick.convert.commands`): Converts a CoPick project into nnUNet raw dataset format. Reads tomograms and multilabel segmentations, writes them as .nii.gz NIfTI files in the imagesTr / 
  labelsTr / imagesTs directory structure, and emits a dataset.json. Voxel spacing is converted from Ångströms to nanometres for nnUNet's patch-size planner. Conversion is multi-threaded.
  - train (`copick.training.commands`): Runs nnUNetv2_plan_and_preprocess followed by nnUNetv2_train. Supports the standard nnUNet trainer, the Residual Encoder Large variant (resnecl), and all ten 
  MedNeXt variants (S/B/M/L × kernel-3/kernel-5). Multi-GPU DDP is supported via --num-gpus; the plans batch size is scaled automatically so per-GPU memory stays constant. Resumes from an existing
   checkpoint if one is found.
  - segment (`copick.inference.commands`): Wraps nnUNet inference as nnUNetPredictor. Single-volume inference runs on cuda:0; batch inference shards runs round-robin across all available GPUs using 
  mp.spawn. Supports fold ensembling (pass multiple -w checkpoint paths). Writes predictions back to the CoPick overlay as multilabel segmentations and saves a YAML parameter log.                 
  - mednext_trainer.py: MedNeXt trainer class definitions (10 variants). Copied into nnUNet's trainer discovery directory on first use so the standard nnUNetv2_train CLI and checkpoint loading
  both work without patching nnUNet.                                                                                                                                                                
                  
  pyproject.toml                                                                                                                                                                                    
  - Adds nnunetv2 and SimpleITK as dependencies.
  - Registers CLI entry points in copick.convert, copick.training, and copick.inference command groups.                                                                                             
                                                                                                       
  Usage sketch                                                                                                                                                                                      
                                                                                                                                                                                                    
  ### 1. Prepare dataset
```
  copick nnunet prepare -c config.json --tomo-uri wbp@10.0 \                                                                                                                                  
      --seg-info targets --dataset-name CZII --raw /data/nnunet_raw
```                                                                                                                                 
                                                                                                                                                                                                    
  ### 2. Train (standard nnUNet, fold 0)                                                                                                                                                              
```
  copick nnunet train -n CZII -r /data/nnunet_raw \                                                                                                                                           
      --preprocessed /data/preprocessed --results /data/results     
```                                                                                                                                
                                                                                                                                                                                                    
 ### 3. Segment
```
  copick nnunet segment -c config.json \                                                                                                                                                      
      -p /data/results/.../nnUNetPlans.json \                                                                                                                                                       
      -d /data/nnunet_raw/Dataset001_CZII/dataset.json \                                                                                                                                            
      -w /data/results/.../fold_0/checkpoint_best.pth 
```   