### PR TITLE
feat: Normalize run options across copick-torch CLI

### DIFF
--- a/copick_torch/entry_points/run_downsample.py
+++ b/copick_torch/entry_points/run_downsample.py
@@ -2,7 +2,12 @@
 
 import click
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import (
+    add_config_option,
+    add_debug_option,
+    add_run_names_option,
+    resolve_run_names,
+)
 from copick.util.log import get_logger
 
 
@@ -13,6 +18,7 @@ from copick.util.log import get_logger
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input tomograms.")
 @optgroup.option(
     "--tomo-alg",
@@ -45,6 +51,7 @@ from copick.util.log import get_logger
 @add_debug_option
 def downsample(
     config: str,
+    run_names,
     tomo_alg: str,
     voxel_size: float,
     target_resolution: float,
@@ -54,10 +61,10 @@ def downsample(
     """
     Downsample tomograms on the GPU with Fourier rescaling.
 
-    For every run in the project, queries the tomogram of the given algorithm at the
-    source voxel spacing, Fourier-rescales it to the target voxel spacing on the GPU,
-    and writes the downsampled tomogram back into the project. Runs are processed in
-    parallel on a GPU pool.
+    For every run in the project (or only the runs given by --run-names/-r), queries
+    the tomogram of the given algorithm at the source voxel spacing, Fourier-rescales
+    it to the target voxel spacing on the GPU, and writes the downsampled tomogram back
+    into the project. Runs are processed in parallel on a GPU pool.
 
     URI Format:
 
@@ -81,15 +88,16 @@ def downsample(
         \b
         copick process bandpass: band-pass filter tomograms without resampling
     """
-    run(config, tomo_alg, voxel_size, target_resolution, delete_source, debug=debug)
+    run(config, tomo_alg, voxel_size, target_resolution, delete_source, run_names=run_names, debug=debug)
 
 
-def run(config, tomo_alg, voxel_size, target_resolution, delete_source, debug=False):
+def run(config, tomo_alg, voxel_size, target_resolution, delete_source, run_names=None, debug=False):
     """
     Runs the downsampling.
     """
 
     import copick
+    from copick.ops.get import get_runs
 
     from copick_torch import parallelization
     from copick_torch.filters import downsample
@@ -97,7 +105,9 @@ def run(config, tomo_alg, voxel_size, target_resolution, delete_source, debug=Fa
     logger = get_logger(__name__, debug=debug)
 
     root = copick.from_file(config)
-    run_ids = [run.name for run in root.runs]
+    run_names_list = resolve_run_names(run_names, logger=logger)
+    runs = get_runs(root, run_names_list)
+    run_ids = [r.name for r in runs]
 
     pool = parallelization.GPUPool(
         init_fn=downsample.downsample_init,
@@ -105,7 +115,7 @@ def run(config, tomo_alg, voxel_size, target_resolution, delete_source, debug=Fa
         verbose=True,
     )
 
-    tasks = [(run, tomo_alg, voxel_size, target_resolution, delete_source) for run in root.runs]
+    tasks = [(r, tomo_alg, voxel_size, target_resolution, delete_source) for r in runs]
 
     # Execute
     try:

--- a/copick_torch/entry_points/run_filter3d.py
+++ b/copick_torch/entry_points/run_filter3d.py
@@ -2,7 +2,13 @@
 
 import click
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import (
+    add_config_option,
+    add_debug_option,
+    add_deprecated_run_alias,
+    add_run_names_option,
+    resolve_run_names,
+)
 from copick.util.log import get_logger
 
 
@@ -48,14 +54,9 @@ def print_header(lp_freq, lp_decay, hp_freq, hp_decay):
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
+@add_deprecated_run_alias("--run-ids")
 @optgroup.group("\nInput Options", help="Options related to the input tomograms.")
-@optgroup.option(
-    "--run-ids",
-    type=str,
-    required=False,
-    default=None,
-    help="Run ID to process (No Input would process the entire dataset.)",
-)
 @optgroup.option("--tomo-alg", type=str, required=True, help="Tomogram Algorithm to use")
 @optgroup.option("--voxel-size", type=float, required=False, default=10, help="Voxel Size to Query the Data")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
@@ -85,7 +86,8 @@ def print_header(lp_freq, lp_decay, hp_freq, hp_decay):
 @add_debug_option
 def bandpass(
     config: str,
-    run_ids: str,
+    run_names,
+    legacy_run_names,
     tomo_alg: str,
     voxel_size: float,
     lp_freq: float,
@@ -98,7 +100,7 @@ def bandpass(
     """
     Band-pass filter tomograms in 3D.
 
-    For every run in the project (or only the runs given by --run-ids), queries the
+    For every run in the project (or only the runs given by --run-names/-r), queries the
     tomogram of the given algorithm at the requested voxel spacing, applies a Gaussian
     band-pass filter on the GPU, and writes the filtered tomogram back into the project
     under a new algorithm name (the source name with -lp<freq>A and/or -hp<freq>A
@@ -125,7 +127,7 @@ def bandpass(
         \b
         # Band-pass a single run between 100 A (high-pass) and 30 A (low-pass)
         copick process bandpass -c config.json --tomo-alg wbp \\
-            --voxel-size 10.0 --run-ids TS_001 --lp-freq 30.0 --hp-freq 100.0
+            --voxel-size 10.0 -r TS_001 --lp-freq 30.0 --hp-freq 100.0
 
         \b
         # High-pass the whole dataset and skip the filter preview PNG
@@ -138,9 +140,12 @@ def bandpass(
         copick process downsample: downsample tomograms via Fourier rescaling
     """
 
+    logger = get_logger(__name__, debug=debug)
+    run_names_list = resolve_run_names(run_names, legacy_run_names, legacy_flag="--run-ids", logger=logger)
+
     run_filter3d(
         config,
-        run_ids,
+        run_names_list,
         lp_freq,
         lp_decay,
         hp_freq,
@@ -188,11 +193,9 @@ def run_filter3d(
 
     print_header(lp_freq, lp_decay, hp_freq, hp_decay)
 
-    # Get Run IDs
+    # Get Run IDs (already resolved to a list of run names, or None for all runs)
     if run_ids is None:
         run_ids = [run.name for run in root.runs]
-    else:
-        run_ids = run_ids.split(",")
 
     # Determine Write Algorithm
     write_algorithm = tomo_alg

--- a/copick_torch/entry_points/run_membrane_seg.py
+++ b/copick_torch/entry_points/run_membrane_seg.py
@@ -2,7 +2,12 @@
 
 import click
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import (
+    add_config_option,
+    add_debug_option,
+    add_run_names_option,
+    resolve_run_names,
+)
 from copick.util.log import get_logger
 
 
@@ -13,6 +18,7 @@ from copick.util.log import get_logger
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input tomograms.")
 @optgroup.option(
     "--tomo-alg",
@@ -54,6 +60,7 @@ from copick.util.log import get_logger
 @add_debug_option
 def membrain_seg(
     config: str,
+    run_names,
     tomo_alg: str,
     voxel_size: float,
     threshold: float,
@@ -64,7 +71,8 @@ def membrain_seg(
     """
     Segment membranes in tomograms with MemBrain-seg.
 
-    For every run in the project, queries the tomogram of the given algorithm at the
+    For every run in the project (or only the runs given by --run-names/-r), queries
+    the tomogram of the given algorithm at the
     requested voxel spacing, runs the MemBrain-seg model with sliding-window inference
     (using test-time augmentation and input normalization), and writes the resulting
     membrane segmentation back into the project. Runs are processed in parallel on a
@@ -96,14 +104,15 @@ def membrain_seg(
         \b
         copick process downsample: downsample tomograms before segmentation
     """
-    run(config, tomo_alg, voxel_size, session_id, threshold, user_id, debug=debug)
+    run(config, tomo_alg, voxel_size, session_id, threshold, user_id, run_names=run_names, debug=debug)
 
 
-def run(config, tomo_alg, voxel_size, session_id, threshold, user_id, debug=False):
+def run(config, tomo_alg, voxel_size, session_id, threshold, user_id, run_names=None, debug=False):
     """
     Runs the membrane segmentation.
     """
     import copick
+    from copick.ops.get import get_runs
 
     from copick_torch import parallelization
     from copick_torch.inference import membrain_seg
@@ -117,7 +126,9 @@ def run(config, tomo_alg, voxel_size, session_id, threshold, user_id, debug=Fals
 
     # Read Copick Project and Get Runs
     root = copick.from_file(config)
-    run_ids = [run.name for run in root.runs]
+    run_names_list = resolve_run_names(run_names, logger=logger)
+    runs = get_runs(root, run_names_list)
+    run_ids = [r.name for r in runs]
 
     # Initialize Parallelization Pool
     pool = parallelization.GPUPool(
@@ -128,7 +139,7 @@ def run(config, tomo_alg, voxel_size, session_id, threshold, user_id, debug=Fals
     # Check to see if model is available
     # If not, download it
 
-    tasks = [(run, tomo_alg, voxel_size, session_id, threshold, user_id) for run in root.runs]
+    tasks = [(r, tomo_alg, voxel_size, session_id, threshold, user_id) for r in runs]
 
     # Execute
     try:

--- a/copick_torch/entry_points/run_picks2slab.py
+++ b/copick_torch/entry_points/run_picks2slab.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 from copick_utils.cli.util import add_dual_input_options, add_output_option, add_tomogram_option, add_workers_option
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_dual_selector_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_dual_input_options("picks")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @add_tomogram_option(required=True)

--- a/copick_torch/entry_points/run_seg2slab.py
+++ b/copick_torch/entry_points/run_seg2slab.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 from copick_utils.cli.util import add_input_option, add_output_option, add_workers_option
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentations.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/copick_torch/nnunet/predict.py
+++ b/copick_torch/nnunet/predict.py
@@ -20,6 +20,9 @@ import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from copick.cli.util import add_deprecated_run_alias, add_run_names_option, resolve_run_names
+from copick.util.log import get_logger
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -516,7 +519,8 @@ class nnUNetPredictor:  # noqa: N801
 )
 @click.option("-turi", "--tomo-uri", type=str, default="wbp@10.0", help="Tomogram URI to predict")
 @click.option("--tta", type=bool, default=True, help="Enable mirroring TTA.")
-@click.option("--run-ids", "-runs", type=str, default=None, help="CoPick run IDs to predict (comma-separated).")
+@add_run_names_option
+@add_deprecated_run_alias("--run-ids", "-runs")
 @click.option(
     "-suri",
     "--seg-uri",
@@ -524,11 +528,11 @@ class nnUNetPredictor:  # noqa: N801
     default="predict:nnunet/1",
     help="Segmentation URI to write (name:user_id/session_id)",
 )
-def cli(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri):
+def cli(config, plans, dataset, tomo_uri, weights, tta, run_names, legacy_run_names, seg_uri):
     """
     Run nnUNet inference on CoPick tomograms.
 
-    For every run in the project, queries the requested tomogram, runs sliding-window
+    For every run in the project (or only the runs given by --run-names/-r), queries the requested tomogram, runs sliding-window
     nnUNet prediction, and writes the resulting segmentation back into the CoPick
     project. All available GPUs are used automatically, with run IDs sharded across
     devices for batch inference.
@@ -553,7 +557,7 @@ def cli(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri):
         \b
         # Predict only specific runs with mirroring TTA disabled
         copick inference nnunet -c config.json -p plans.json -d dataset.json \\
-            -w fold_0/checkpoint_best.pth -runs TS_01,TS_02 --tta False
+            -w fold_0/checkpoint_best.pth -r TS_01 -r TS_02 --tta False
 
     See Also:
 
@@ -561,11 +565,13 @@ def cli(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri):
         copick convert nnunet: build the nnUNet training dataset from a CoPick project
         copick training nnunet: train the nnUNet model used for inference
     """
-    run_predict(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri)
+    logger = get_logger(__name__)
+    run_ids_list = resolve_run_names(run_names, legacy_run_names, legacy_flag="--run-ids", logger=logger)
+    run_predict(config, plans, dataset, tomo_uri, weights, tta, run_ids_list, seg_uri)
 
 
 def run_predict(config, plans, dataset, tomo_uri, weights, tta, run_ids, seg_uri):
-    run_ids_list = run_ids.split(",") if run_ids else None
+    run_ids_list = list(run_ids) if run_ids else None
 
     predictor = nnUNetPredictor(
         plans=plans,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "copick-utils>=1.7.0",
     "scikit-image",
     "scipy",
-    "copick>=1.20.0",
+    "copick>=1.26.0",
     "zarr",
     "mrcfile",
     "gdown",

--- a/tests/test_run_names_option.py
+++ b/tests/test_run_names_option.py
@@ -1,0 +1,54 @@
+"""Tests that copick-torch CLI commands use the standardized run-selection option.
+
+Verifies each command exposes ``--run-names``/``-r`` (from ``copick.cli.util``) and
+that the commands whose flag was renamed keep a hidden, still-working ``--run-ids``
+deprecated alias.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _load_command(dotted, attr):
+    import importlib
+
+    return getattr(importlib.import_module(dotted), attr)
+
+
+ENTRY_POINT_COMMANDS = [
+    ("copick_torch.entry_points.run_filter3d", "bandpass"),
+    ("copick_torch.entry_points.run_downsample", "downsample"),
+    ("copick_torch.entry_points.run_membrane_seg", "membrain_seg"),
+    ("copick_torch.entry_points.run_picks2slab", "picks2slab"),
+    ("copick_torch.entry_points.run_seg2slab", "seg2slab"),
+    ("copick_torch.nnunet.predict", "cli"),
+]
+
+
+@pytest.mark.parametrize(("dotted", "attr"), ENTRY_POINT_COMMANDS)
+def test_command_exposes_standard_run_option(runner, dotted, attr):
+    cmd = _load_command(dotted, attr)
+    out = runner.invoke(cmd, ["--help"]).output
+    assert "--run-names" in out
+    assert "-r" in out
+    assert "--run-ids" not in out  # renamed; alias is hidden
+
+
+@pytest.mark.parametrize(
+    ("dotted", "attr"),
+    [
+        ("copick_torch.entry_points.run_filter3d", "bandpass"),
+        ("copick_torch.nnunet.predict", "cli"),
+    ],
+)
+def test_deprecated_run_ids_alias_registered_hidden(dotted, attr):
+    cmd = _load_command(dotted, attr)
+    alias = next((p for p in cmd.params if "--run-ids" in getattr(p, "opts", [])), None)
+    assert alias is not None, "deprecated --run-ids alias should still be registered"
+    assert alias.hidden is True
+    assert alias.name == "legacy_run_names"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -887,7 +887,7 @@ wheels = [
 
 [[package]]
 name = "copick"
-version = "1.24.1"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -917,9 +917,9 @@ dependencies = [
     { name = "trimesh" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b0/b51272bbb882241e6f45edcc1d8cf4256c69244616d4cabdbad10ec28284/copick-1.24.1.tar.gz", hash = "sha256:6197cc9b939c1d04e40d912b8f654ea639d534c23348ed1a86316ea6ec4832c1", size = 9426087, upload-time = "2026-05-05T03:27:28.617Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/9b/29f6db0b642e45a3b761f442204c971b098653c4f22f151b86779490d953/copick-1.26.0.tar.gz", hash = "sha256:7ca35d829caa1dd911946d4e1393196224493ddf7b896b339ce023f88119db41", size = 47782928, upload-time = "2026-07-07T22:08:20.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/2c/1e80dda158f7a8178ec8d42e0fa2cc079e815fecb66c82dca4dc5f352f68/copick-1.24.1-py3-none-any.whl", hash = "sha256:e774f3a685cb9ce5dc8bcdbee922d48382c67275bcd2236f3842970b5262df6a", size = 197915, upload-time = "2026-05-05T03:27:26.636Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/09/a9cd473da5efa7fded7a67cb8d3194269497cbdb4552e1b1d50f8052910d/copick-1.26.0-py3-none-any.whl", hash = "sha256:d6bbc53162d75ca1443d01b2cdb3ccac4fcc5cba9f2ec526d6f1f041b82b823f", size = 223179, upload-time = "2026-07-07T22:08:17.758Z" },
 ]
 
 [[package]]
@@ -972,7 +972,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.1.0" },
-    { name = "copick", specifier = ">=1.20.0" },
+    { name = "copick", specifier = ">=1.26.0" },
     { name = "copick-utils", specifier = ">=1.7.0" },
     { name = "dask" },
     { name = "einops" },


### PR DESCRIPTION
Normalizes the run selection option across most of the copick CLIs to `-r/--run-names`