### PR TITLE
test: establish copick-torch storage migration gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main, v2.0 ]
   pull_request:
-    branches: [ main, v2.0 ]
 
 jobs:
   test:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+markers =
+    portal: bounded tests that access the public CryoET Data Portal
 
 # Coverage settings
-addopts = --cov=copick_torch --cov-report=term --cov-report=xml --cov-report=html
+addopts = -m "not portal" --cov=copick_torch --cov-report=term --cov-report=xml --cov-report=html

--- a/tests/storage_helpers.py
+++ b/tests/storage_helpers.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import numpy as np
+import zarr
+
+
+class CountingMemoryStore(zarr.storage.MemoryStore):
+    """In-memory Zarr v2 store that records reads of array payload keys."""
+
+    def __init__(self):
+        super().__init__()
+        self.payload_reads = []
+
+    def __getitem__(self, key):
+        value = super().__getitem__(key)
+        if not key.endswith((".zarray", ".zattrs", ".zgroup")):
+            self.payload_reads.append(key)
+        return value
+
+
+def make_v2_store(dataset_path="0", data=None):
+    """Build a small metadata-valid OME-Zarr 0.4 / Zarr v2 group."""
+    if data is None:
+        data = np.arange(8 * 9 * 10, dtype=np.float32).reshape(8, 9, 10)
+
+    store = CountingMemoryStore()
+    group = zarr.group(store=store, overwrite=True)
+    group.create_dataset(dataset_path, data=data, chunks=(4, 4, 4))
+    group.attrs["multiscales"] = [
+        {
+            "version": "0.4",
+            "axes": [
+                {"name": "z", "type": "space", "unit": "angstrom"},
+                {"name": "y", "type": "space", "unit": "angstrom"},
+                {"name": "x", "type": "space", "unit": "angstrom"},
+            ],
+            "datasets": [
+                {
+                    "path": dataset_path,
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": [10.0, 10.0, 10.0]},
+                    ],
+                },
+            ],
+        },
+    ]
+    store.payload_reads.clear()
+    return store, np.asarray(data)
+
+
+def make_entity(store, *, tomo_type="wbp-denoised", name="particle"):
+    """Return the smallest entity double needed by the storage consumers."""
+    return SimpleNamespace(
+        tomo_type=tomo_type,
+        meta=SimpleNamespace(name=name),
+        zarr=lambda: store,
+    )

--- a/tests/test_copick_data_portal_distribution.py
+++ b/tests/test_copick_data_portal_distribution.py
@@ -8,10 +8,12 @@ from unittest.mock import MagicMock, patch
 
 import copick
 import numpy as np
+import pytest
 
 from copick_torch.dataset import SimpleCopickDataset
 
 
+@pytest.mark.portal
 class TestCopickDataPortalDistribution(unittest.TestCase):
     """
     Test that verifies the SimpleCopickDataset correctly preserves the

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ from copick_torch.copick import CopickDataset
 TEST_CONFIG_PATH = os.environ.get("COPICK_TEST_CONFIG", "./examples/czii_object_detection_training.json")
 
 
+@pytest.mark.portal
 @pytest.mark.skipif(not os.path.exists(TEST_CONFIG_PATH), reason="Test config file not available")
 class TestIntegration(unittest.TestCase):
     """Integration tests that require actual data.

--- a/tests/test_minimal_dataset.py
+++ b/tests/test_minimal_dataset.py
@@ -1,197 +1,69 @@
-import os
-import shutil
-import tempfile
+import json
 import unittest
-from unittest.mock import MagicMock, patch
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 
 import numpy as np
-import torch
 
 from copick_torch.minimal_dataset import MinimalCopickDataset
+from tests.storage_helpers import make_entity, make_v2_store
 
 
 class TestMinimalCopickDataset(unittest.TestCase):
-    """
-    Test the MinimalCopickDataset class.
-    """
+    """Exercise the eager and saved-lazy entity-store consumers."""
 
-    pass
+    def test_dataset_initialization_reads_numeric_ome_level(self):
+        store, expected = make_v2_store("0")
+        tomogram = make_entity(store)
+        voxel_spacing = SimpleNamespace(tomograms=[tomogram])
+        run = SimpleNamespace(
+            name="run-1",
+            get_voxel_spacing=lambda _voxel_size: voxel_spacing,
+            get_picks=lambda: [],
+        )
+        project = SimpleNamespace(
+            runs=[run],
+            pickable_objects=[SimpleNamespace(name="particle", label=1)],
+        )
 
-    # TODO: Uncomment and fix the tests below
+        dataset = MinimalCopickDataset(proj=project, voxel_spacing=10.0, preload=False)
 
-    # @patch("zarr.open")
-    # @patch("copick.from_czcdp_datasets")
-    # def test_dataset_initialization(self, mock_from_czcdp, mock_zarr_open):
-    #     """Test that the dataset can be initialized and returns correct data."""
-    #     # Set up mocks
-    #     mock_copick_root = MagicMock()
-    #     mock_run = MagicMock()
-    #     mock_vs = MagicMock()
-    #     mock_tomogram = MagicMock()
-    #
-    #     # Configure mocks
-    #     mock_from_czcdp.return_value = mock_copick_root
-    #     mock_copick_root.runs = [mock_run]
-    #     mock_copick_root.pickable_objects = [MagicMock(name="object1"), MagicMock(name="object2")]
-    #
-    #     for po in mock_copick_root.pickable_objects:
-    #         po.name = po.name
-    #
-    #     mock_run.name = "test_run"
-    #     mock_run.get_voxel_spacing.return_value = mock_vs
-    #     mock_vs.tomograms = [mock_tomogram]
-    #     mock_tomogram.tomo_type = "wbp-denoised"
-    #
-    #     # Setup picks for each object
-    #     mock_picks_list = []
-    #     for po in mock_copick_root.pickable_objects:
-    #         mock_pick = MagicMock()
-    #         mock_pick.from_tool = True
-    #         mock_pick.pickable_object_name = po.name
-    #         # Create 5 points for each object
-    #         mock_pick.numpy.return_value = (
-    #             np.array([[100, 100, 100], [200, 200, 200], [300, 300, 300], [400, 400, 400], [500, 500, 500]]),
-    #             None,
-    #         )
-    #         mock_picks_list.append(mock_pick)
-    #
-    #     mock_run.get_picks.return_value = mock_picks_list
-    #
-    #     # Mock zarr.open to return a dummy array
-    #     mock_zarr_root = MagicMock()
-    #     mock_zarr_open.return_value = mock_zarr_root
-    #     # Create a dummy 3D array
-    #     dummy_array = np.random.randn(100, 100, 100)
-    #     mock_zarr_root.__getitem__.return_value = dummy_array
-    #     mock_tomogram.zarr.return_value = "dummy_zarr_path"
-    #
-    #     # Create the dataset
-    #     dataset = MinimalCopickDataset(
-    #         dataset_id=10440,
-    #         overlay_root="/tmp/test/",
-    #         boxsize=(32, 32, 32),
-    #         voxel_spacing=10.0,
-    #         include_background=True,
-    #         background_ratio=0.2,
-    #     )
-    #
-    #     # Test the dataset properties
-    #     self.assertIsNotNone(dataset)
-    #     self.assertEqual(dataset.dataset_id, 10440)
-    #     self.assertEqual(dataset.boxsize, (32, 32, 32))
-    #     self.assertEqual(dataset.voxel_spacing, 10.0)
-    #     self.assertTrue(dataset.include_background)
-    #
-    #     # Check the class names
-    #     expected_class_names = ["object1", "object2"]
-    #     if dataset.include_background:
-    #         expected_class_names.append("background")
-    #
-    #     self.assertEqual(set(dataset.keys()), set(expected_class_names))
-    #
-    #     # Test length - with 5 points per object (2 objects) and background_ratio of 0.2,
-    #     # we expect 10 object points + approximately 2 background points
-    #     # However, the exact number of background points may vary due to random sampling
-    #     # So we just check it's at least the total object points
-    #     self.assertGreaterEqual(len(dataset), 10)
-    #
-    #     # Test getting an item
-    #     volume, label = dataset[0]
-    #
-    #     # Check the shape and type
-    #     self.assertEqual(volume.shape, (1, 32, 32, 32))  # [C, D, H, W]
-    #     self.assertIsInstance(volume, torch.Tensor)
-    #     self.assertIsInstance(label, int)
-    #
-    #     # Check label is in the expected range
-    #     self.assertIn(label, [-1, 0, 1])  # -1 for background, 0-1 for objects
-    #
-    #     # Test the class distribution
-    #     distribution = dataset.get_class_distribution()
-    #
-    #     # Check each object has 5 points
-    #     for obj_name in expected_class_names[:2]:  # Skip "background"
-    #         self.assertEqual(distribution.get(obj_name, 0), 5)
-    #
-    #     # Test sample weights
-    #     weights = dataset.get_sample_weights()
-    #     self.assertEqual(len(weights), len(dataset))
+        self.assertEqual(len(dataset._tomogram_data), 1)
+        np.testing.assert_array_equal(dataset._tomogram_data[0], expected)
 
-    # @patch("zarr.open")
-    # @patch("copick.from_czcdp_datasets")
-    # def test_class_to_label_consistency(self, mock_from_czcdp, mock_zarr_open):
-    #     """Test that class names and labels are consistent."""
-    #     # Set up mocks (simplified version compared to above)
-    #     mock_copick_root = MagicMock()
-    #     mock_run = MagicMock()
-    #     mock_vs = MagicMock()
-    #     mock_tomogram = MagicMock()
-    #
-    #     # Configure mocks
-    #     mock_from_czcdp.return_value = mock_copick_root
-    #     mock_copick_root.runs = [mock_run]
-    #     mock_copick_root.pickable_objects = [
-    #         MagicMock(name="object1"),
-    #         MagicMock(name="object2"),
-    #         MagicMock(name="object3"),
-    #     ]
-    #
-    #     for po in mock_copick_root.pickable_objects:
-    #         po.name = po.name
-    #
-    #     mock_run.name = "test_run"
-    #     mock_run.get_voxel_spacing.return_value = mock_vs
-    #     mock_vs.tomograms = [mock_tomogram]
-    #     mock_tomogram.tomo_type = "wbp-denoised"
-    #
-    #     # Setup picks - just one point per object for simplicity
-    #     mock_picks_list = []
-    #     for i, po in enumerate(mock_copick_root.pickable_objects):
-    #         mock_pick = MagicMock()
-    #         mock_pick.from_tool = True
-    #         mock_pick.pickable_object_name = po.name
-    #         mock_pick.numpy.return_value = (np.array([[100 * (i + 1), 100 * (i + 1), 100 * (i + 1)]]), None)
-    #         mock_picks_list.append(mock_pick)
-    #
-    #     mock_run.get_picks.return_value = mock_picks_list
-    #
-    #     # Mock zarr.open to return a dummy array
-    #     mock_zarr_root = MagicMock()
-    #     mock_zarr_open.return_value = mock_zarr_root
-    #     mock_zarr_root.__getitem__.return_value = np.zeros((500, 500, 500))
-    #     mock_tomogram.zarr.return_value = "dummy_zarr_path"
-    #
-    #     # Create the dataset without background for simpler testing
-    #     dataset = MinimalCopickDataset(
-    #         dataset_id=10440,
-    #         overlay_root="/tmp/test/",
-    #         boxsize=(32, 32, 32),
-    #         voxel_spacing=10.0,
-    #         include_background=False,  # No background samples
-    #     )
-    #
-    #     # Check length - should be exactly 3 points (one per object)
-    #     self.assertEqual(len(dataset), 3)
-    #
-    #     # Verify class names and indices
-    #     class_names = dataset.keys()
-    #     self.assertEqual(len(class_names), 3)
-    #
-    #     # For each sample, verify the label matches the expected class
-    #     for i in range(len(dataset)):
-    #         _, label = dataset[i]
-    #         # The label should be a valid index in the class_names list
-    #         self.assertTrue(0 <= label < len(class_names))
-    #         # Get the class name from the label
-    #         class_name = class_names[label]
-    #         # Make sure it's one of our expected class names
-    #         self.assertIn(class_name, ["object1", "object2", "object3"])
-    #
-    #     # Test that the class distribution is correct
-    #     distribution = dataset.get_class_distribution()
-    #
-    #     for name in ["object1", "object2", "object3"]:
-    #         self.assertEqual(distribution.get(name, 0), 1)
+    def test_lazy_reload_retains_numeric_zarr_array(self):
+        store, expected = make_v2_store("0")
+        tomogram = make_entity(store)
+        voxel_spacing = SimpleNamespace(tomograms=[tomogram])
+        project = SimpleNamespace(
+            runs=[SimpleNamespace(get_voxel_spacing=lambda _voxel_size: voxel_spacing)],
+        )
+
+        with TemporaryDirectory() as save_dir:
+            metadata = {
+                "dataset_id": None,
+                "boxsize": [4, 4, 4],
+                "voxel_spacing": 10.0,
+                "include_background": False,
+                "background_ratio": 0.0,
+                "min_background_distance": 4,
+                "name_to_label": {"particle": 1},
+                "preload": False,
+            }
+            samples = [{"point": [20, 20, 20], "label": 1, "is_background": False, "tomogram_idx": 0}]
+            tomograms = [{"index": 0, "shape": list(expected.shape), "path": "0"}]
+            for name, value in (
+                ("metadata.json", metadata),
+                ("samples.json", samples),
+                ("tomogram_info.json", tomograms),
+            ):
+                with open(f"{save_dir}/{name}", "w") as stream:
+                    json.dump(value, stream)
+
+            dataset = MinimalCopickDataset.load(save_dir, proj=project)
+
+        self.assertEqual(dataset._tomogram_data[0].shape, expected.shape)
+        np.testing.assert_array_equal(dataset._tomogram_data[0][1:3, 2:4, 3:5], expected[1:3, 2:4, 3:5])
 
 
 if __name__ == "__main__":

--- a/tests/test_spliced_mixup_dataset.py
+++ b/tests/test_spliced_mixup_dataset.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 
 from copick_torch.dataset import SplicedMixupDataset
+from tests.storage_helpers import make_entity, make_v2_store
 
 
 class TestSplicedMixupDataset(unittest.TestCase):
@@ -110,6 +111,34 @@ class TestSplicedMixupDataset(unittest.TestCase):
         # With Gaussian blending, more pixels should be affected than just the mask
         affected_pixels_gaussian = result_gaussian > 0.01
         self.assertTrue(np.sum(affected_pixels_gaussian) > np.sum(region_mask))
+
+    def test_zarr_loading_methods_use_numeric_level(self):
+        exp_store, exp = make_v2_store("0")
+        synth_store, synth = make_v2_store("0", exp + 1000)
+        mask_store, mask = make_v2_store("0", (exp % 3 == 0).astype(np.uint8))
+
+        dataset = SplicedMixupDataset.__new__(SplicedMixupDataset)
+        dataset.voxel_spacing = 10.0
+        dataset.exp_root = object()
+        dataset.synth_root = object()
+        dataset._synth_mask_data = {}
+        entities = {
+            id(dataset.exp_root): [make_entity(exp_store)],
+            id(dataset.synth_root): [make_entity(synth_store)],
+        }
+        dataset._get_available_tomograms = lambda root, _voxel_size: entities[id(root)]
+        dataset._get_segmentation_masks = lambda _root, _voxel_size: {
+            "particle": make_entity(mask_store, name="particle"),
+        }
+
+        dataset._load_experimental_zarr()
+        dataset._load_synthetic_zarr()
+        dataset._load_segmentation_masks()
+
+        np.testing.assert_allclose(dataset._exp_zarr_data.mean(), 0.0, atol=1e-6)
+        np.testing.assert_allclose(dataset._exp_zarr_data.std(), 1.0, atol=1e-6)
+        np.testing.assert_allclose(dataset._synth_zarr_data.mean(), 0.0, atol=1e-6)
+        np.testing.assert_array_equal(dataset._synth_mask_data["particle"], mask)
 
 
 if __name__ == "__main__":

--- a/tests/test_storage_consumers.py
+++ b/tests/test_storage_consumers.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from copick_torch.entry_points.run_filter3d import get_tomo_shape
+from copick_torch.fitting.slab_from_picks import slab_from_picks
+from tests.storage_helpers import make_entity, make_v2_store
+
+
+def test_filter_shape_lookup_does_not_read_array_payload():
+    store, expected = make_v2_store("0")
+    tomogram = make_entity(store)
+    voxel_spacing = SimpleNamespace(get_tomogram=lambda _tomo_type: tomogram)
+    run = SimpleNamespace(get_voxel_spacing=lambda _voxel_size: voxel_spacing)
+    root = SimpleNamespace(get_run=lambda _run_name: run)
+
+    assert get_tomo_shape(root, ["run-1"], "wbp", 10.0) == expected.shape
+    assert store.payload_reads == []
+
+
+def test_slab_shape_lookup_does_not_read_array_payload():
+    store, expected = make_v2_store("0")
+    tomogram = make_entity(store)
+    voxel_spacing = SimpleNamespace(get_tomogram=lambda _tomo_type: tomogram)
+    run = SimpleNamespace(get_voxel_spacing=lambda _voxel_size: voxel_spacing)
+    points = [[10.0, 10.0, 10.0], [20.0, 20.0, 10.0], [10.0, 20.0, 10.0]]
+    picks = SimpleNamespace(
+        points=[SimpleNamespace(location=SimpleNamespace(x=x, y=y, z=z)) for x, y, z in points],
+    )
+    surface = np.zeros((4, 3), dtype=np.float32)
+    sentinel = object()
+
+    with (
+        patch(
+            "copick_torch.fitting.slab_from_picks.fit_parallel_planes_from_picks",
+            return_value=(np.array([0.0, 0.0, 1.0]), 0.25, 0.5),
+        ),
+        patch("copick_torch.fitting.slab_from_picks.evaluate_plane_on_grid", return_value=surface),
+        patch("copick_torch.fitting.slab_from_picks.triangulate_box", return_value=sentinel),
+        patch("copick_torch.fitting.slab_from_picks.store_mesh_with_stats", return_value=sentinel),
+    ):
+        result = slab_from_picks(
+            picks,
+            picks,
+            run,
+            "slab",
+            "session",
+            "user",
+            "wbp",
+            10.0,
+            method="parallel",
+        )
+
+    assert result is sentinel
+    assert expected.shape == (8, 9, 10)
+    assert store.payload_reads == []
+
+
+def test_numeric_and_nonnumeric_v2_fixtures_are_decoded_equivalent():
+    numeric_store, expected = make_v2_store("0")
+    nonnumeric_store, _ = make_v2_store("s0", expected)
+
+    numeric = np.asarray(__import__("zarr").open(numeric_store, mode="r")["0"])
+    nonnumeric = np.asarray(__import__("zarr").open(nonnumeric_store, mode="r")["s0"])
+
+    np.testing.assert_array_equal(numeric, nonnumeric)


### PR DESCRIPTION
## Summary

- add real OME-Zarr 0.4 / Zarr v2 numeric and nonnumeric fixtures
- activate focused coverage for all seven direct package storage consumers
- prove the filter and slab shape paths do not request array payloads
- mark public-portal tests explicitly and keep them out of the deterministic job
- run unit and lint workflows for pull requests targeting any branch so every stacked layer is gated

This is stack 1/4 and targets `v2.0`. The next PR is based on this branch.

Part of #138 and #137.

## Verification

- `69 passed, 3 deselected` on the locked pre-migration stack
- Ruff and formatting checks pass for changed files
