### PR TITLE
test: verify copick-torch parity across Zarr layouts

### DIFF
--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -70,14 +70,17 @@ def test_fourier_augment3d():
     # Test initialization
     aug = FourierAugment3D(freq_mask_prob=0.3, phase_noise_std=0.1, intensity_scaling_range=(0.8, 1.2), prob=1.0)
 
-    # Apply augmentation
-    augmented = aug(volume)
+    # Force a deterministic non-identity transform. Random behavior is covered
+    # separately by the channel-first test below.
+    aug._mask = None
+    aug._phase_noise = torch.zeros_like(volume)
+    aug._intensity_scale = 1.2
+    augmented = aug(volume, randomize=False)
 
     # Check shape preservation
     assert augmented.shape == volume.shape
 
-    # Make sure the augmentation changed the volume (not identity)
-    assert not torch.allclose(augmented, volume, rtol=1e-3, atol=1e-3)
+    assert torch.allclose(augmented, volume * 1.2, rtol=1e-3, atol=1e-3)
 
     # Test with zero phase noise and fixed intensity scale (should be close to identity
     # if there's no masking)

--- a/tests/test_zarr_consumer_parity.py
+++ b/tests/test_zarr_consumer_parity.py
@@ -1,0 +1,165 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import zarr
+from zarr.codecs import BloscCodec, GzipCodec, Shuffle, ZstdCodec
+from zarr.storage import LocalStore
+
+from copick_torch.copick import CopickDataset
+from copick_torch.dataset import SimpleCopickDataset, SplicedMixupDataset
+from copick_torch.minimal_dataset import MinimalCopickDataset
+from copick_torch.nnunet.prepare import load_segmentation, load_volume
+from copick_torch.storage import get_level_array
+
+V3_LAYOUTS = {
+    "unsharded-default-keys": {
+        "chunks": (2, 3, 5),
+        "compressors": None,
+    },
+    "alternate-chunks-gzip": {
+        "chunks": (4, 3, 2),
+        "compressors": (GzipCodec(level=1),),
+    },
+    "unsharded-v2-keys-blosc": {
+        "chunks": (2, 3, 5),
+        "compressors": (BloscCodec(cname="lz4", clevel=1),),
+        "chunk_key_encoding": {"name": "v2", "separator": "/"},
+    },
+    "multishard-shuffle-zstd": {
+        "chunks": (1, 3, 5),
+        "shards": (4, 6, 10),
+        "compressors": (Shuffle(elementsize=2), ZstdCodec(level=1)),
+    },
+}
+
+
+class StoredEntity:
+    def __init__(self, store):
+        self._store = store
+        self.tomo_type = "wbp-denoised"
+        self.voxel_size = 10.0
+        self.meta = SimpleNamespace(name="particle")
+
+    def zarr(self):
+        return self._store
+
+    def numpy(self):
+        return get_level_array(self)[:]
+
+
+def write_store(path, layout):
+    values = np.arange(8 * 9 * 10, dtype=np.int16).reshape(8, 9, 10)
+    store = LocalStore(path)
+    if layout == "legacy-v2-numeric":
+        group = zarr.group(store=store, zarr_format=2)
+        group.create_array("0", data=values, chunks=(2, 3, 5))
+        group.attrs["multiscales"] = [
+            {
+                "version": "0.4",
+                "axes": [{"name": axis, "type": "space", "unit": "angstrom"} for axis in ("z", "y", "x")],
+                "datasets": [
+                    {
+                        "path": "0",
+                        "coordinateTransformations": [{"type": "scale", "scale": [10.0, 10.0, 10.0]}],
+                    },
+                ],
+            },
+        ]
+    else:
+        group = zarr.group(store=store, zarr_format=3)
+        group.create_array("s0", data=values, dimension_names=("z", "y", "x"), **V3_LAYOUTS[layout])
+        group.attrs["ome"] = {
+            "version": "0.5",
+            "multiscales": [
+                {
+                    "axes": [{"name": axis, "type": "space", "unit": "angstrom"} for axis in ("z", "y", "x")],
+                    "datasets": [
+                        {
+                            "path": "s0",
+                            "coordinateTransformations": [{"type": "scale", "scale": [10.0, 10.0, 10.0]}],
+                        },
+                    ],
+                },
+            ],
+        }
+    return StoredEntity(store), values
+
+
+def project_for(entity):
+    picks = SimpleNamespace(
+        from_tool=True,
+        pickable_object_name="particle",
+        numpy=lambda: (np.array([[50.0, 40.0, 30.0]]), None),
+    )
+    voxel_spacing = SimpleNamespace(tomograms=[entity])
+    run = SimpleNamespace(
+        name="run-1",
+        get_voxel_spacing=lambda _voxel_size: voxel_spacing,
+        get_picks=lambda: [picks],
+    )
+    return SimpleNamespace(
+        runs=[run],
+        pickable_objects=[SimpleNamespace(name="particle", label=1)],
+    )
+
+
+def snapshot(path: Path):
+    return {item.relative_to(path).as_posix(): item.read_bytes() for item in path.rglob("*") if item.is_file()}
+
+
+def consume(entity):
+    root = project_for(entity)
+    copick_dataset = CopickDataset(copick_root=root, boxsize=(4, 4, 4), voxel_spacing=10.0, seed=1)
+    simple_dataset = SimpleCopickDataset(copick_root=root, boxsize=(4, 4, 4), voxel_spacing=10.0, seed=1)
+    minimal_dataset = MinimalCopickDataset(proj=root, boxsize=(4, 4, 4), voxel_spacing=10.0, preload=False)
+
+    spliced_dataset = SplicedMixupDataset.__new__(SplicedMixupDataset)
+    spliced_dataset.voxel_spacing = 10.0
+    spliced_dataset.exp_root = object()
+    spliced_dataset.synth_root = object()
+    spliced_dataset._synth_mask_data = {}
+    spliced_dataset._get_available_tomograms = lambda _root, _voxel_size: [entity]
+    spliced_dataset._get_segmentation_masks = lambda _root, _voxel_size: {"particle": entity}
+    spliced_dataset._load_experimental_zarr()
+    spliced_dataset._load_synthetic_zarr()
+    spliced_dataset._load_segmentation_masks()
+
+    with patch("copick.util.uri.resolve_copick_objects", return_value=[entity]):
+        nnunet_volume = load_volume(root, "copick://tomogram", "run-1")
+        nnunet_segmentation = load_segmentation(root, "copick://segmentation", "run-1")
+
+    minimal_patch, minimal_label = minimal_dataset[0]
+    return {
+        "copick-patches": copick_dataset._subvolumes,
+        "copick-labels": copick_dataset._molecule_ids,
+        "simple-patches": simple_dataset._subvolumes,
+        "simple-labels": simple_dataset._molecule_ids,
+        "minimal-patch": minimal_patch.numpy(),
+        "minimal-label": minimal_label,
+        "spliced-experimental": spliced_dataset._exp_zarr_data,
+        "spliced-synthetic": spliced_dataset._synth_zarr_data,
+        "spliced-mask": spliced_dataset._synth_mask_data["particle"],
+        "nnunet-volume": nnunet_volume,
+        "nnunet-segmentation": nnunet_segmentation,
+    }
+
+
+@pytest.mark.parametrize("layout", V3_LAYOUTS)
+def test_dataset_consumers_are_equivalent_across_v2_and_v3_layouts(tmp_path, layout):
+    legacy_path = tmp_path / "legacy.zarr"
+    migrated_path = tmp_path / f"{layout}.zarr"
+    legacy, expected = write_store(legacy_path, "legacy-v2-numeric")
+    migrated, _ = write_store(migrated_path, layout)
+    before = snapshot(migrated_path)
+
+    legacy_result = consume(legacy)
+    migrated_result = consume(migrated)
+
+    assert set(legacy_result) == set(migrated_result)
+    for key in legacy_result:
+        np.testing.assert_array_equal(migrated_result[key], legacy_result[key])
+    np.testing.assert_array_equal(migrated.numpy(), expected)
+    assert snapshot(migrated_path) == before

--- a/tests/test_zarr_consumer_parity.py
+++ b/tests/test_zarr_consumer_parity.py
@@ -15,6 +15,12 @@ from copick_torch.nnunet.prepare import load_segmentation, load_volume
 from copick_torch.storage import get_level_array
 
 V3_LAYOUTS = {
+    "canonical-one-shard": {
+        "chunks": (128, 128, 128),
+        "shards": (128, 128, 128),
+        "compressors": (Shuffle(elementsize=2), ZstdCodec(level=3)),
+        "chunk_key_encoding": {"name": "v2", "separator": "/"},
+    },
     "unsharded-default-keys": {
         "chunks": (2, 3, 5),
         "compressors": None,
@@ -153,7 +159,8 @@ def test_dataset_consumers_are_equivalent_across_v2_and_v3_layouts(tmp_path, lay
     migrated_path = tmp_path / f"{layout}.zarr"
     legacy, expected = write_store(legacy_path, "legacy-v2-numeric")
     migrated, _ = write_store(migrated_path, layout)
-    before = snapshot(migrated_path)
+    legacy_before = snapshot(legacy_path)
+    migrated_before = snapshot(migrated_path)
 
     legacy_result = consume(legacy)
     migrated_result = consume(migrated)
@@ -162,4 +169,5 @@ def test_dataset_consumers_are_equivalent_across_v2_and_v3_layouts(tmp_path, lay
     for key in legacy_result:
         np.testing.assert_array_equal(migrated_result[key], legacy_result[key])
     np.testing.assert_array_equal(migrated.numpy(), expected)
-    assert snapshot(migrated_path) == before
+    assert snapshot(legacy_path) == legacy_before
+    assert snapshot(migrated_path) == migrated_before


### PR DESCRIPTION
## Summary

- compare `CopickDataset`, `SimpleCopickDataset`, and `MinimalCopickDataset` across v2/v3 twins
- exercise all three `SplicedMixupDataset` storage loaders without patching them away
- compare nnUNet preparation reads across the same sources
- cover the canonical one-shard writer layout plus alternate chunks/codecs, unsharded and multishard arrays, and default/v2 chunk keys
- assert read-only consumers leave both legacy and migrated source files byte-for-byte unchanged
- make the Fourier augmentation regression deterministic with forced non-identity parameters

This is stack 3/4 and targets the metadata-read branch.

Part of #140 and #137.

## Verification

- five layout-parity cases pass
- included in the 87-test green run at the stack tip
